### PR TITLE
vers login to store api key, cli now auths requests 

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/google/uuid"
 	vers "github.com/hdresearch/vers-sdk-go"
 	"github.com/spf13/cobra"
 )
@@ -19,13 +18,6 @@ var upCmd = &cobra.Command{
 	Long:  `Start a Vers development environment according to the configuration in vers.toml.`,
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterName := fmt.Sprintf("new-cluster-%s", uuid.New())
-		if len(args) > 0 {
-			clusterName = args[0]
-		}
-
-		fmt.Printf("Preparing cluster parameters for cluster: %s\n", clusterName)
-
 		baseCtx := context.Background()
 
 		apiCtx, cancel := context.WithTimeout(baseCtx, 30*time.Second)
@@ -36,7 +28,7 @@ var upCmd = &cobra.Command{
 		fmt.Println("Sending request to start cluster...")
 		clusterInfo, err := client.API.Cluster.New(apiCtx, clusterParams)
 		if err != nil {
-			return fmt.Errorf("failed to start cluster '%s': %w", clusterName, err)
+			return fmt.Errorf("failed to start cluster: %w", err)
 		}
 		// Use information from the response (adjust field names as needed)
 		fmt.Printf("Cluster (ID: %s) started successfully with root vm '%s'.\n",


### PR DESCRIPTION
All unauthed CLI commands will fail and prompt the user to run `vers login`.

`vers login` prompts the user to enter their API key (which we currently give to users manually). `vers login` will store the API key at the user's home directory in a `.versrc` file. When the client is initialized by `rootCmd`, it checks this `.versrc` config file for the API key. 

SDK version: https://github.com/hdresearch/vers-sdk-go/pull/24