### PR TITLE
pause and resume commands in the CLI

### DIFF
--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hdresearch/vers-cli/styles"
+	vers "github.com/hdresearch/vers-sdk-go"
+	"github.com/spf13/cobra"
+)
+
+// pauseCmd represents the pause command
+var pauseCmd = &cobra.Command{
+	Use:   "pause [vm-id]",
+	Short: "Pause a running VM",
+	Long:  `Pause a running Vers VM. If no VM ID is provided, uses the current HEAD.`,
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var vmID string
+		s := styles.NewKillStyles()
+
+		// If no VM ID provided, try to use the current HEAD
+		if len(args) == 0 {
+			var err error
+			vmID, err = getCurrentHeadVM()
+			if err != nil {
+				return fmt.Errorf(s.NoData.Render("no VM ID provided and %w"), err)
+			}
+			fmt.Printf(s.HeadStatus.Render("Using current HEAD VM: "+vmID) + "\n")
+		} else {
+			vmID = args[0]
+		}
+
+		// Initialize context
+		baseCtx := context.Background()
+		apiCtx, cancel := context.WithTimeout(baseCtx, 30*time.Second)
+		defer cancel()
+
+		fmt.Printf(s.Progress.Render("Pausing VM '%s'...\n"), vmID)
+
+		// Create pause request using SDK
+		patchRequest := vers.PatchRequestParam{
+			Action: vers.F(vers.PatchRequestActionPause),
+		}
+
+		updateParams := vers.APIVmUpdateStateParams{
+			PatchRequest: patchRequest,
+		}
+
+		// Make API call to pause the VM
+		response, err := client.API.Vm.UpdateState(apiCtx, vmID, updateParams)
+		if err != nil {
+			return fmt.Errorf(s.NoData.Render("failed to pause VM '%s': %w"), vmID, err)
+		}
+
+		fmt.Printf(s.Success.Render("✓ VM '%s' paused successfully\n"), response.Data.ID)
+		fmt.Printf(s.HeadStatus.Render("VM state: %s\n"), response.Data.State)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pauseCmd)
+}

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hdresearch/vers-cli/styles"
+	vers "github.com/hdresearch/vers-sdk-go"
+	"github.com/spf13/cobra"
+)
+
+// resumeCmd represents the resume command
+var resumeCmd = &cobra.Command{
+	Use:   "resume [vm-id]",
+	Short: "Resume a paused VM",
+	Long:  `Resume a paused Vers VM. If no VM ID is provided, uses the current HEAD.`,
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var vmID string
+		s := styles.NewKillStyles()
+
+		// If no VM ID provided, try to use the current HEAD
+		if len(args) == 0 {
+			var err error
+			vmID, err = getCurrentHeadVM()
+			if err != nil {
+				return fmt.Errorf(s.NoData.Render("no VM ID provided and %w"), err)
+			}
+			fmt.Printf(s.HeadStatus.Render("Using current HEAD VM: "+vmID) + "\n")
+		} else {
+			vmID = args[0]
+		}
+
+		// Initialize context
+		baseCtx := context.Background()
+		apiCtx, cancel := context.WithTimeout(baseCtx, 30*time.Second)
+		defer cancel()
+
+		fmt.Printf(s.Progress.Render("Resuming VM '%s'...\n"), vmID)
+
+		// Create resume request using SDK
+		patchRequest := vers.PatchRequestParam{
+			Action: vers.F(vers.PatchRequestActionResume),
+		}
+
+		updateParams := vers.APIVmUpdateStateParams{
+			PatchRequest: patchRequest,
+		}
+
+		// Make API call to resume the VM
+		response, err := client.API.Vm.UpdateState(apiCtx, vmID, updateParams)
+		if err != nil {
+			return fmt.Errorf(s.NoData.Render("failed to resume VM '%s': %w"), vmID, err)
+		}
+
+		fmt.Printf(s.Success.Render("✓ VM '%s' resumed successfully\n"), response.Data.ID)
+		fmt.Printf(s.HeadStatus.Render("VM state: %s\n"), response.Data.State)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(resumeCmd)
+}


### PR DESCRIPTION
Previously, the `pause` and `resume` commands did not yet exist in the CLI. This PR adds both commands so that users can pause a running VM, or resume one which should be running. Per @asebexen , the backend should prevent a VM with any children from being resumed, so this does not check for possible errors. Error checking can be added if that is necessary.