### PR TITLE
SSH key output

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -39,7 +39,6 @@ var connectCmd = &cobra.Command{
 		apiCtx, cancel := context.WithTimeout(baseCtx, 30*time.Second)
 		defer cancel()
 
-		fmt.Println(s.NoData.Render("Fetching VM information..."))
 		response, err := client.API.Vm.Get(apiCtx, vmID)
 		if err != nil {
 			return fmt.Errorf(s.NoData.Render("failed to get VM information: %w"), err)
@@ -54,17 +53,16 @@ var connectCmd = &cobra.Command{
 			return fmt.Errorf("%s", s.NoData.Render("VM does not have SSH port information available"))
 		}
 
-		fmt.Printf(s.HeadStatus.Render("Connecting to VM %s..."), vmID)
-
 		hostIP := auth.GetVersUrl()
 
-		// Debug info about connection
-		fmt.Printf(s.HeadStatus.Render("Connecting to %s on port %d\n"), hostIP, vm.NetworkInfo.SSHPort)
-
+		// Get SSH key (will show "Fetching SSH key..." only if not cached)
 		keyPath, err := auth.GetOrCreateSSHKey(vmID, client, apiCtx)
 		if err != nil {
 			return fmt.Errorf("failed to get or create SSH key: %w", err)
 		}
+
+		// Single clear connection message
+		fmt.Printf(s.HeadStatus.Render("Connecting to %s:%d...\n"), hostIP, vm.NetworkInfo.SSHPort)
 
 		sshCmd := exec.Command("ssh",
 			fmt.Sprintf("root@%s", hostIP),

--- a/internal/auth/keys.go
+++ b/internal/auth/keys.go
@@ -26,30 +26,28 @@ func GetOrCreateSSHKey(vmID string, client *vers.Client, apiCtx context.Context)
 
 	// Check if SSH key already exists
 	if _, err := os.Stat(keyPath); err == nil {
-		// Key exists, return the path
-		fmt.Println(s.HeadStatus.Render(fmt.Sprintf("Using existing SSH key from %s", keyPath)))
+		// Key exists, return the path silently (no output for cached keys)
 		return keyPath, nil
 	}
 
+	// Key doesn't exist, need to fetch it
+	fmt.Println(s.HeadStatus.Render("Fetching SSH key..."))
+
 	keysDir := filepath.Dir(keyPath)
 	if err := os.MkdirAll(keysDir, 0755); err != nil {
-		// Return empty path and the error
 		return "", fmt.Errorf(s.NoData.Render("failed to create keys directory: %w"), err)
 	}
 
 	response, err := client.API.Vm.GetSSHKey(apiCtx, vmID)
 	if err != nil {
-		// Return empty path and the error
 		return "", fmt.Errorf(s.NoData.Render("failed to get SSH key: %w"), err)
 	}
 	sshKeyBytes := response.Data
 
 	if err := os.WriteFile(keyPath, []byte(sshKeyBytes), 0600); err != nil {
-		// Return empty path and the error
 		return "", fmt.Errorf(s.NoData.Render("failed to write key file: %w"), err)
 	}
 
-	fmt.Println(s.HeadStatus.Render(fmt.Sprintf("SSH key saved to %s", keyPath)))
-	// Return the path and nil error on success
+	fmt.Println(s.HeadStatus.Render("SSH key saved and ready"))
 	return keyPath, nil
 }


### PR DESCRIPTION
We aren't reconnecting the SSH key every time `vers connect` is run, just checking that it exists locally. This PR changes some of the output to the CLI so that this is made more apparent.