### PR TITLE
--version and --VVersion subcommands + adding debug logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,30 @@
+# Version information
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Manifest information - can be overridden
+NAME ?= vers-cli
+DESCRIPTION ?= A CLI tool for version management
+AUTHOR ?= Tynan Daly
+REPOSITORY ?= https://github.com/tynandaly/vers-cli
+LICENSE ?= MIT
+
+# Build flags
+LDFLAGS = -s -w \
+	-X 'github.com/hdresearch/vers-cli/cmd.Version=$(VERSION)' \
+	-X 'github.com/hdresearch/vers-cli/cmd.GitCommit=$(GIT_COMMIT)' \
+	-X 'github.com/hdresearch/vers-cli/cmd.BuildDate=$(BUILD_DATE)' \
+	-X 'github.com/hdresearch/vers-cli/cmd.Name=$(NAME)' \
+	-X 'github.com/hdresearch/vers-cli/cmd.Description=$(DESCRIPTION)' \
+	-X 'github.com/hdresearch/vers-cli/cmd.Author=$(AUTHOR)' \
+	-X 'github.com/hdresearch/vers-cli/cmd.Repository=$(REPOSITORY)' \
+	-X 'github.com/hdresearch/vers-cli/cmd.License=$(LICENSE)'
+
 # Build the vers binary
 .PHONY: build
 build:
-	go build -o bin/vers ./cmd/vers
+	go build -ldflags "$(LDFLAGS)" -o bin/vers ./cmd/vers
 
 # Clean build artifacts
 .PHONY: clean

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
+	"time"
 
 	"github.com/hdresearch/vers-cli/internal/auth"
 	vers "github.com/hdresearch/vers-sdk-go"
@@ -11,10 +14,67 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// These variables are set at build time using ldflags
+var (
+	// Core version info
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+
+	// Manifest info
+	Name        = "vers-cli"
+	Description = "A CLI tool for version management"
+	Author      = "the VERS team"
+	Repository  = "https://github.com/tynandaly/vers-cli"
+	License     = "MIT"
+)
+
 // Global vars for configuration and SDK client
 var (
-	client *vers.Client
+	client  *vers.Client
+	verbose bool
 )
+
+// MetadataInfo represents the complete version information
+type MetadataInfo struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Description string `json:"description"`
+	GitCommit   string `json:"gitCommit"`
+	BuildDate   string `json:"buildDate"`
+	Author      string `json:"author"`
+	Repository  string `json:"repository"`
+	License     string `json:"license"`
+	GoVersion   string `json:"goVersion"`
+	Platform    string `json:"platform"`
+	Arch        string `json:"arch"`
+	Timestamp   string `json:"timestamp"`
+}
+
+// getVersionInfo returns the complete version information
+func getVersionInfo() *MetadataInfo {
+	return &MetadataInfo{
+		Name:        Name,
+		Version:     Version,
+		Description: Description,
+		GitCommit:   GitCommit,
+		BuildDate:   BuildDate,
+		Author:      Author,
+		Repository:  Repository,
+		License:     License,
+		GoVersion:   runtime.Version(),
+		Platform:    runtime.GOOS,
+		Arch:        runtime.GOARCH,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// DebugPrint prints debug information only when verbose mode is enabled
+func DebugPrint(format string, args ...interface{}) {
+	if verbose {
+		fmt.Printf("[DEBUG] "+format, args...)
+	}
+}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -23,7 +83,39 @@ var rootCmd = &cobra.Command{
 	Long: `Vers CLI provides a command-line interface for managing virtual machine/container-based 
 development environments. It offers lifecycle management, state management, 
 interaction capabilities, and more.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Handle --VVersion flag
+		if vversion, _ := cmd.Flags().GetBool("VVersion"); vversion {
+			versionInfo := getVersionInfo()
+			jsonOutput, err := json.MarshalIndent(versionInfo, "", "  ")
+			if err != nil {
+				fmt.Printf("Error marshalling version info: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Println(string(jsonOutput))
+			return
+		}
+
+		// If no command specified, show help
+		cmd.Help()
+	},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Handle version flags before any authentication
+		if version, _ := cmd.Flags().GetBool("version"); version {
+			fmt.Println(Version)
+			os.Exit(0)
+		}
+
+		if vversion, _ := cmd.Flags().GetBool("VVersion"); vversion {
+			// This will be handled in the Run function
+			return nil
+		}
+
+		// Set verbose environment variable for other packages to use
+		if verbose {
+			os.Setenv("VERS_VERBOSE", "true")
+		}
+
 		if cmd.Name() == "login" || cmd.Name() == "help" || cmd.CalledAs() == "help" {
 			return nil
 		}
@@ -71,6 +163,17 @@ func Execute() {
 }
 
 func init() {
+	// Add global persistent flags
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+
+	// Add version flags
+	rootCmd.Flags().Bool("version", false, "Show version information")
+	rootCmd.Flags().Bool("VVersion", false, "Show detailed version and build information")
+
+	// Handle version flag (simple version)
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+	rootCmd.Version = Version
+
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -140,7 +140,11 @@ func GetClientOptions() []option.RequestOption {
 
 	// Set the base URL with protocol
 	clientOptions = append(clientOptions, option.WithBaseURL(fullUrl))
-	fmt.Println("Using API endpoint: ", fullUrl)
+
+	// This will be handled by the calling function that has access to verbose flag
+	if os.Getenv("VERS_VERBOSE") == "true" {
+		fmt.Printf("[DEBUG] Using API endpoint: %s\n", fullUrl)
+	}
 
 	return clientOptions
 }


### PR DESCRIPTION
Adds `--version` and `--VVersion` flags that produce the short version + full metadata. Also added a `-v` flag for verbose output (we shouldn't print the api url every time)