### PR TITLE
Adds in rudimentary alias support

### DIFF
--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	"github.com/hdresearch/vers-cli/styles"
+	"github.com/hdresearch/vers-sdk-go"
 	"github.com/spf13/cobra"
 )
 
 var fromBranch string
-var branchName string
+var branchName string // TODO: Remove!
+var alias string
 
 // branchCmd represents the branch command
 var branchCmd = &cobra.Command{
@@ -87,7 +89,14 @@ var branchCmd = &cobra.Command{
 		defer cancel()
 
 		fmt.Println(s.Progress.Render("Creating branch..."))
-		response, err := client.API.Vm.Branch(apiCtx, vmName)
+		body := vers.APIVmBranchParams{
+			BranchRequest: vers.BranchRequestParam{},
+		}
+		if alias != "" {
+			body.BranchRequest.Alias = vers.F(alias)
+		}
+
+		response, err := client.API.Vm.Branch(apiCtx, vmName, body)
 		if err != nil {
 			return fmt.Errorf(s.Error.Render("failed to create branch of vm '%s': %w"), vmName, err)
 		}
@@ -173,6 +182,6 @@ func init() {
 
 	// Define flags for the branch command
 	branchCmd.Flags().StringVarP(&fromBranch, "from", "f", "", "Source branch or commit (default: current state)")
-	branchCmd.Flags().StringVarP(&branchName, "name", "n", "", "Name for the new branch")
+	branchCmd.Flags().StringVarP(&alias, "alias", "n", "", "Alias for the new VM")
 	branchCmd.Flags().BoolP("checkout", "c", false, "Checkout the new branch after creation")
 }

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -61,7 +61,7 @@ var connectCmd = &cobra.Command{
 		// Debug info about connection
 		fmt.Printf(s.HeadStatus.Render("Connecting to %s on port %d\n"), hostIP, vm.NetworkInfo.SSHPort)
 
-		keyPath, err := auth.GetOrCreateSSHKey(vmID, client, apiCtx)
+		keyPath, err := auth.GetOrCreateSSHKey(vm.ID, client, apiCtx)
 		if err != nil {
 			return fmt.Errorf("failed to get or create SSH key: %w", err)
 		}

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -55,7 +55,7 @@ var killCmd = &cobra.Command{
 			}
 
 			fmt.Printf(s.Progress.Render("Deleting cluster '%s'...\n"), targetID)
-			_, err := client.API.Cluster.Delete(apiCtx, targetID)
+			err := client.API.Cluster.Delete(apiCtx, targetID)
 			if err != nil {
 				return fmt.Errorf(s.Error.Render("failed to delete cluster: %w"), err)
 			}

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -40,16 +40,14 @@ var pauseCmd = &cobra.Command{
 		fmt.Printf(s.Progress.Render("Pausing VM '%s'...\n"), vmID)
 
 		// Create pause request using SDK
-		patchRequest := vers.PatchRequestParam{
-			Action: vers.F(vers.PatchRequestActionPause),
-		}
-
-		updateParams := vers.APIVmUpdateStateParams{
-			PatchRequest: patchRequest,
+		updateParams := vers.APIVmUpdateParams{
+			UpdateVm: vers.UpdateVmParam{
+				State: vers.F(vers.UpdateVmStatePaused),
+			},
 		}
 
 		// Make API call to pause the VM
-		response, err := client.API.Vm.UpdateState(apiCtx, vmID, updateParams)
+		response, err := client.API.Vm.Update(apiCtx, vmID, updateParams)
 		if err != nil {
 			return fmt.Errorf(s.NoData.Render("failed to pause VM '%s': %w"), vmID, err)
 		}

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hdresearch/vers-cli/styles"
+	vers "github.com/hdresearch/vers-sdk-go"
+	"github.com/spf13/cobra"
+)
+
+// renameCmd represents the rename command
+var renameCmd = &cobra.Command{
+	Use:   "rename [vm-id] [new-alias]",
+	Short: "Rename a VM or cluster",
+	Long:  `Rename a VM or cluster by setting a new alias. Use -c flag for clusters.`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		newAlias := args[1]
+		s := styles.NewKillStyles()
+
+		// Initialize context
+		baseCtx := context.Background()
+		apiCtx, cancel := context.WithTimeout(baseCtx, 30*time.Second)
+		defer cancel()
+
+		// Check if this is a cluster rename
+		isCluster, _ := cmd.Flags().GetBool("cluster")
+		if isCluster {
+			fmt.Printf(s.Progress.Render("Renaming cluster '%s' to '%s'...\n"), id, newAlias)
+
+			// Create cluster rename request
+			updateParams := vers.APIClusterUpdateParams{
+				UpdateCluster: vers.UpdateClusterParam{
+					Alias: vers.F(newAlias),
+				},
+			}
+
+			// Make API call to rename the cluster
+			response, err := client.API.Cluster.Update(apiCtx, id, updateParams)
+			if err != nil {
+				return fmt.Errorf(s.NoData.Render("failed to rename cluster '%s': %w"), id, err)
+			}
+
+			fmt.Printf(s.Success.Render("✓ Cluster '%s' renamed to '%s'\n"), response.Data.ID, response.Data.Alias)
+		} else {
+			fmt.Printf(s.Progress.Render("Renaming VM '%s' to '%s'...\n"), id, newAlias)
+
+			// Create VM rename request
+			updateParams := vers.APIVmUpdateParams{
+				UpdateVm: vers.UpdateVmParam{
+					Alias: vers.F(newAlias),
+				},
+			}
+
+			// Make API call to rename the VM
+			response, err := client.API.Vm.Update(apiCtx, id, updateParams)
+			if err != nil {
+				return fmt.Errorf(s.NoData.Render("failed to rename VM '%s': %w"), id, err)
+			}
+
+			fmt.Printf(s.Success.Render("✓ VM '%s' renamed to '%s'\n"), response.Data.ID, response.Data.Alias)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(renameCmd)
+	renameCmd.Flags().BoolP("cluster", "c", false, "Rename a cluster instead of a VM")
+}

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -40,16 +40,14 @@ var resumeCmd = &cobra.Command{
 		fmt.Printf(s.Progress.Render("Resuming VM '%s'...\n"), vmID)
 
 		// Create resume request using SDK
-		patchRequest := vers.PatchRequestParam{
-			Action: vers.F(vers.PatchRequestActionResume),
-		}
-
-		updateParams := vers.APIVmUpdateStateParams{
-			PatchRequest: patchRequest,
+		updateParams := vers.APIVmUpdateParams{
+			UpdateVm: vers.UpdateVmParam{
+				State: vers.F(vers.UpdateVmStateRunning),
+			},
 		}
 
 		// Make API call to resume the VM
-		response, err := client.API.Vm.UpdateState(apiCtx, vmID, updateParams)
+		response, err := client.API.Vm.Update(apiCtx, vmID, updateParams)
 		if err != nil {
 			return fmt.Errorf(s.NoData.Render("failed to resume VM '%s': %w"), vmID, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15
+	github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250612001305-594ca437ac72
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.9.1
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250612001305-594ca437ac72
+	github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250617065043-0fd33e1c201d
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,10 @@ github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNE
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15 h1:YFX7CebZJmW01jhtSf5j32+3aztJiwANG74XCPXjTcI=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250611190259-268911ddbeee h1:DPIV2Hs+D9NgHnwELGM83ZAMryHxKpLuclUPQsrUquI=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250611190259-268911ddbeee/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250612001305-594ca437ac72 h1:ZefC8knSR2PJ/JrwC97Kr/yV1mmS4cEMLiD8smHZOsQ=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250612001305-594ca437ac72/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250611190259-268911ddbeee 
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250611190259-268911ddbeee/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250612001305-594ca437ac72 h1:ZefC8knSR2PJ/JrwC97Kr/yV1mmS4cEMLiD8smHZOsQ=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250612001305-594ca437ac72/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250617065043-0fd33e1c201d h1:fRjLcfrLEX0DBrFD/qTlHxzP4iC9xINDD7UqEtVfip0=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.15.0.20250617065043-0fd33e1c201d/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=


### PR DESCRIPTION
This PR adds in a couple of things related to aliases, as well as making some SDK adjustments that are relevant to the sister PR on Chelsea: https://github.com/hdresearch/chelsea/pull/159

```
vers run -n cluster-alias -N vm-alias;
vers rename -c cluster-alias coolCluster;
vers branch vm-alias -n branch-alias;
vers rename branch-alias coolBranch;
vers connect coolBranch;
```

This PR does not address user output/display very much; there are a lot of places in the CLI where we can use the alias instead of/in addition to the IDs, namely in `vers status` and `vers tree` and friends, but I just wanted to get the basics up.

As always, remember to fetch the staging branch of the SDK in order to rebuild the CLI.