### PR TITLE
CLI points to LB. this is backwards compatible but maybe shouldnt be

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -12,11 +15,64 @@ import (
 
 var token string
 
+// validateAPIKey validates the API key against vers-lb
+// TODO: Remove backward compatibility after migration period (target: later this week should be fine honestly, just don't want to spring this out of nowhere)
+func validateAPIKey(apiKey string) error {
+	validateURL := "https://api.vers.sh/keys/validate"
+
+	payload := map[string]string{
+		"api_key": apiKey,
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("error preparing validation request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", validateURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("error creating validation request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		// BACKWARD COMPATIBILITY: If validation fails due to network/server issues,
+		// allow the key to be saved anyway (old behavior)
+		// TODO: Remove this fallback after migration period
+		fmt.Printf("Warning: Could not validate API key against server (%v), but saving anyway for backward compatibility\n", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 401 {
+		// BACKWARD COMPATIBILITY: If the key is invalid on the new system,
+		// still allow it to be saved (it might be an old-format key)
+		// TODO: Remove this fallback after migration period
+		fmt.Println("Warning: API key not recognized by new validation system, but saving anyway for backward compatibility")
+		return nil
+	}
+
+	if resp.StatusCode != 200 {
+		// BACKWARD COMPATIBILITY: For other errors, still allow saving
+		// TODO: Remove this fallback after migration period
+		fmt.Printf("Warning: Validation returned status %d, but saving anyway for backward compatibility\n", resp.StatusCode)
+		return nil
+	}
+
+	// Key validated successfully against new system
+	fmt.Println("API key validated successfully")
+	return nil
+}
+
 // loginCmd represents the login command
 var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Authenticate with the Vers platform",
-	Long:  `Login to the Vers platform using your credentials or API token.`,
+	Long:  `Login to the Vers platform using your API token.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if token == "" {
 			fmt.Print("Enter your API key: ")
@@ -31,7 +87,16 @@ var loginCmd = &cobra.Command{
 			}
 		}
 
-		err := auth.SaveAPIKey(token)
+		// Attempt to validate the API key against vers-lb
+		// This is non-blocking for backward compatibility
+		err := validateAPIKey(token)
+		if err != nil {
+			// This should never happen with current implementation, but just in case
+			return fmt.Errorf("unexpected validation error: %w", err)
+		}
+
+		// Save the API key (validated or not, for backward compatibility)
+		err = auth.SaveAPIKey(token)
 		if err != nil {
 			return fmt.Errorf("error saving API key: %w", err)
 		}
@@ -43,7 +108,5 @@ var loginCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(loginCmd)
-
-	// Define flags for the login command
 	loginCmd.Flags().StringVarP(&token, "token", "t", "", "API token for authentication")
 }


### PR DESCRIPTION
CLI now points to LB. This is backwards compatible, so old API endpoints created using the old system should still work, but it can easily be changed so they don't (which is also simpler). I don't know if that's necessary, but I thought to do it this way at first out of an abundance of caution.