### PR TITLE
Resolves #57: Do not make unnecessary API call

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -114,27 +114,12 @@ var executeCmd = &cobra.Command{
 			return fmt.Errorf("failed to get or create SSH key: %w", err)
 		}
 
-		// Use the node IP from headers or fallback to load balancer
-		var hostIP string
-		if nodeIP != "" {
-			hostIP = nodeIP
-		} else {
-			// Fallback to load balancer URL
-			hostIP, err = auth.GetVersUrlHost()
-			if err != nil {
-				return fmt.Errorf("failed to get host IP: %w", err)
-			}
-			if os.Getenv("VERS_DEBUG") == "true" {
-				fmt.Printf("[DEBUG] No node IP in headers, using fallback: %s\n", hostIP)
-			}
-		}
-
 		// // Debug info about connection
 		// fmt.Printf(s.HeadStatus.Render("Executing command via SSH on %s (VM %s)\n"), hostIP, vmID)
 
 		// Create the SSH command with the provided command string
 		sshCmd := exec.Command("ssh",
-			fmt.Sprintf("root@%s", hostIP),
+			fmt.Sprintf("root@%s", nodeIP),
 			"-p", fmt.Sprintf("%d", vm.NetworkInfo.SSHPort),
 			"-o", "StrictHostKeyChecking=no",
 			"-o", "UserKnownHostsFile=/dev/null", // Avoid host key prompts

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -272,9 +272,9 @@ func setupIntegrationClient(t *testing.T) {
 	os.Setenv("VERS_API_KEY", apiKey)
 
 	// Get client options
-	clientOptions := auth.GetClientOptions()
-	if clientOptions == nil {
-		t.Fatalf("Failed to get client options")
+	clientOptions, err := auth.GetClientOptions()
+	if err != nil {
+		t.Fatalf("Failed to get client options: %v", err)
 	}
 
 	// Initialize global client


### PR DESCRIPTION
Due to a limitation within Stainless, I cannot *directly* use the strongly-typed API function calls because they do not expose a headers object. However, if I use the lower-level Client.Get and then just parse the response body, I can. So I've added the GetVmAndNodeIP function for this specific use case. This may be a thing to mention to the Stainless devs, assuming they aren't already aware of it. Exposing a headers object for other requests would be really nice. :)

Resolves #57 