### PR TITLE
Allow commit command to accept VM ID

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -74,14 +74,25 @@ func getActiveBranchName(versDir string) string {
 
 // commitCmd represents the commit command
 var commitCmd = &cobra.Command{
-	Use:   "commit",
+	Use:   "commit [vm-id]",
 	Short: "Commit the current state of the environment",
-	Long:  `Save the current state of the Vers environment as a commit.`,
+	Long:  `Save the current state of the Vers environment as a commit. If no VM ID is provided, commits the current HEAD VM.`,
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get the current HEAD VM ID
-		vmID, err := getCurrentHeadVM()
-		if err != nil {
-			return fmt.Errorf("failed to get current VM: %w", err)
+		var vmID string
+		var err error
+
+		// Check if VM ID was provided as an argument
+		if len(args) > 0 {
+			vmID = args[0]
+			fmt.Printf("Using provided VM ID: %s\n", vmID)
+		} else {
+			// Get the current HEAD VM ID
+			vmID, err = getCurrentHeadVM()
+			if err != nil {
+				return fmt.Errorf("failed to get current VM: %w", err)
+			}
+			fmt.Printf("Using current HEAD VM: %s\n", vmID)
 		}
 
 		fmt.Printf("Creating commit for VM '%s'\n", vmID)


### PR DESCRIPTION
Previously, `vers commit` would only work on the HEAD VM. Now, it accepts a VM ID as an optional argument.