### PR TITLE
commit and log commands use new DB

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -1,118 +1,18 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
-	"github.com/hdresearch/vers-cli/internal/auth"
 	"github.com/hdresearch/vers-cli/internal/utils"
+	"github.com/hdresearch/vers-sdk-go"
 	"github.com/spf13/cobra"
 )
 
 var individualTags []string
 var commaSeparatedTags string
-
-// CommitWithTagsOptions represents the request body for commits with optional tags and cluster info
-type CommitWithTagsOptions struct {
-	Tags      []string `json:"tags,omitempty"`
-	ClusterID string   `json:"cluster_id,omitempty"`
-}
-
-// APIVmCommitResponse represents the response from the commit API
-type APIVmCommitResponse struct {
-	Data struct {
-		ID string `json:"id"`
-		// Add other fields as needed based on your actual API response
-	} `json:"data"`
-}
-
-// CommitWithTags makes a commit request with optional tags array and cluster ID
-func CommitWithTags(ctx context.Context, vmID string, tags []string, clusterID string) (*APIVmCommitResponse, error) {
-	// Get the base URL using the same method as login.go
-	baseURL, err := auth.GetVersUrl()
-	if err != nil {
-		return nil, fmt.Errorf("error getting API URL: %w", err)
-	}
-
-	// Build the commit URL
-	commitURL := fmt.Sprintf("%s/api/vm/%s/commit", baseURL, vmID)
-
-	// Get the API key using the same method as the SDK
-	apiKey, err := auth.GetAPIKey()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get API key: %w", err)
-	}
-
-	// Prepare request body if we have tags or cluster ID
-	var requestBody []byte
-	if len(tags) > 0 || clusterID != "" {
-		// Filter out empty tags
-		filteredTags := make([]string, 0)
-		for _, tag := range tags {
-			if trimmed := strings.TrimSpace(tag); trimmed != "" {
-				filteredTags = append(filteredTags, trimmed)
-			}
-		}
-
-		payload := CommitWithTagsOptions{
-			Tags:      filteredTags,
-			ClusterID: clusterID,
-		}
-		var err error
-		requestBody, err = json.Marshal(payload)
-		if err != nil {
-			return nil, fmt.Errorf("error preparing request body: %w", err)
-		}
-	}
-
-	// Create the HTTP request
-	var req *http.Request
-	if requestBody != nil {
-		req, err = http.NewRequestWithContext(ctx, "POST", commitURL, bytes.NewBuffer(requestBody))
-		if err != nil {
-			return nil, fmt.Errorf("error creating request: %w", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-	} else {
-		req, err = http.NewRequestWithContext(ctx, "POST", commitURL, nil)
-		if err != nil {
-			return nil, fmt.Errorf("error creating request: %w", err)
-		}
-	}
-
-	// Set auth header
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-
-	// Execute the request
-	client := &http.Client{Timeout: 60 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error executing commit request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Handle error responses
-	if resp.StatusCode == 401 {
-		return nil, fmt.Errorf("authentication failed - please run 'vers login' to re-authenticate")
-	}
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("commit request failed with status %d", resp.StatusCode)
-	}
-
-	// Parse the response
-	var response APIVmCommitResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("error parsing commit response: %w", err)
-	}
-
-	return &response, nil
-}
 
 // combineAllTags combines tags from both --tag and --tags flags
 func combineAllTags() []string {
@@ -185,13 +85,18 @@ var commitCmd = &cobra.Command{
 			vmInfo = utils.CreateVMInfoFromGetResponse(vmResponse.Data)
 		}
 
-		response, err := CommitWithTags(apiCtx, vmInfo.ID, allTags, vmInfo.ClusterID)
+		body := vers.APIVmCommitParams{
+			VmCommitRequest: vers.VmCommitRequestParam{
+				Tags: vers.F(allTags),
+			},
+		}
+		response, err := client.API.Vm.Commit(apiCtx, vmInfo.ID, body)
 		if err != nil {
 			return fmt.Errorf("failed to commit VM '%s': %w", vmInfo.DisplayName, err)
 		}
 
 		fmt.Printf("Successfully committed VM '%s'\n", vmInfo.DisplayName)
-		fmt.Printf("Commit ID: %s\n", response.Data.ID)
+		fmt.Printf("Commit ID: %s\n", response.Data.CommitID)
 		if len(allTags) > 0 {
 			fmt.Printf("Tags: %s\n", strings.Join(allTags, ", "))
 		}

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -1,15 +1,103 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
+	"github.com/hdresearch/vers-cli/internal/auth"
 	"github.com/hdresearch/vers-cli/internal/utils"
 	"github.com/spf13/cobra"
 )
 
 var tag string
+
+// CommitWithTagOptions represents the request body for commits with optional tag
+type CommitWithTagOptions struct {
+	Tag *string `json:"tag,omitempty"`
+}
+
+// APIVmCommitResponse represents the response from the commit API
+type APIVmCommitResponse struct {
+	Data struct {
+		ID string `json:"id"`
+		// Add other fields as needed based on your actual API response
+	} `json:"data"`
+}
+
+// CommitWithTag makes a commit request with an optional tag using the same auth pattern as login.go
+func CommitWithTag(ctx context.Context, vmID string, tag *string) (*APIVmCommitResponse, error) {
+	// Get the base URL using the same method as login.go
+	baseURL, err := auth.GetVersUrl()
+	if err != nil {
+		return nil, fmt.Errorf("error getting API URL: %w", err)
+	}
+
+	// Build the commit URL
+	commitURL := fmt.Sprintf("%s/api/vm/%s/commit", baseURL, vmID)
+
+	// Get the API key using the same method as the SDK
+	apiKey, err := auth.GetAPIKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API key: %w", err)
+	}
+
+	// Prepare request body if we have a tag
+	var requestBody []byte
+	if tag != nil && *tag != "" {
+		payload := CommitWithTagOptions{Tag: tag}
+		requestBody, err = json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("error preparing request body: %w", err)
+		}
+	}
+
+	// Create the HTTP request using the same pattern as login.go
+	var req *http.Request
+	if requestBody != nil {
+		req, err = http.NewRequestWithContext(ctx, "POST", commitURL, bytes.NewBuffer(requestBody))
+		if err != nil {
+			return nil, fmt.Errorf("error creating request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, err = http.NewRequestWithContext(ctx, "POST", commitURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error creating request: %w", err)
+		}
+	}
+
+	// Set auth header using the same pattern as login.go
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	// Execute the request using the same pattern as login.go
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error executing commit request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Handle error responses
+	if resp.StatusCode == 401 {
+		return nil, fmt.Errorf("authentication failed - please run 'vers login' to re-authenticate")
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("commit request failed with status %d", resp.StatusCode)
+	}
+
+	// Parse the response
+	var response APIVmCommitResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("error parsing commit response: %w", err)
+	}
+
+	return &response, nil
+}
 
 // commitCmd represents the commit command
 var commitCmd = &cobra.Command{
@@ -59,15 +147,19 @@ var commitCmd = &cobra.Command{
 			vmInfo = utils.CreateVMInfoFromGetResponse(vmResponse.Data)
 		}
 
-		// Call the SDK to commit the VM state
-		response, err := client.API.Vm.Commit(apiCtx, vmInfo.ID)
+		// Call our custom CommitWithTag function instead of the SDK's Commit method
+		var tagPtr *string
+		if tag != "" {
+			tagPtr = &tag
+		}
+
+		response, err := CommitWithTag(apiCtx, vmInfo.ID, tagPtr)
 		if err != nil {
 			return fmt.Errorf("failed to commit VM '%s': %w", vmInfo.DisplayName, err)
 		}
-		commitResult := response.Data
 
 		fmt.Printf("Successfully committed VM '%s'\n", vmInfo.DisplayName)
-		fmt.Printf("Commit ID: %s\n", commitResult.ID)
+		fmt.Printf("Commit ID: %s\n", response.Data.ID)
 
 		return nil
 	},

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hdresearch/vers-cli/internal/auth"
@@ -13,11 +14,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var tag string
+var tags []string
 
-// CommitWithTagOptions represents the request body for commits with optional tag
-type CommitWithTagOptions struct {
-	Tag *string `json:"tag,omitempty"`
+// CommitWithTagsOptions represents the request body for commits with optional tags
+type CommitWithTagsOptions struct {
+	Tags []string `json:"tags,omitempty"`
 }
 
 // APIVmCommitResponse represents the response from the commit API
@@ -28,8 +29,8 @@ type APIVmCommitResponse struct {
 	} `json:"data"`
 }
 
-// CommitWithTag makes a commit request with an optional tag using the same auth pattern as login.go
-func CommitWithTag(ctx context.Context, vmID string, tag *string) (*APIVmCommitResponse, error) {
+// CommitWithTags makes a commit request with optional tags array
+func CommitWithTags(ctx context.Context, vmID string, tags []string) (*APIVmCommitResponse, error) {
 	// Get the base URL using the same method as login.go
 	baseURL, err := auth.GetVersUrl()
 	if err != nil {
@@ -45,17 +46,27 @@ func CommitWithTag(ctx context.Context, vmID string, tag *string) (*APIVmCommitR
 		return nil, fmt.Errorf("failed to get API key: %w", err)
 	}
 
-	// Prepare request body if we have a tag
+	// Prepare request body if we have tags
 	var requestBody []byte
-	if tag != nil && *tag != "" {
-		payload := CommitWithTagOptions{Tag: tag}
-		requestBody, err = json.Marshal(payload)
-		if err != nil {
-			return nil, fmt.Errorf("error preparing request body: %w", err)
+	if len(tags) > 0 {
+		// Filter out empty tags
+		filteredTags := make([]string, 0)
+		for _, tag := range tags {
+			if trimmed := strings.TrimSpace(tag); trimmed != "" {
+				filteredTags = append(filteredTags, trimmed)
+			}
+		}
+
+		if len(filteredTags) > 0 {
+			payload := CommitWithTagsOptions{Tags: filteredTags}
+			requestBody, err = json.Marshal(payload)
+			if err != nil {
+				return nil, fmt.Errorf("error preparing request body: %w", err)
+			}
 		}
 	}
 
-	// Create the HTTP request using the same pattern as login.go
+	// Create the HTTP request
 	var req *http.Request
 	if requestBody != nil {
 		req, err = http.NewRequestWithContext(ctx, "POST", commitURL, bytes.NewBuffer(requestBody))
@@ -70,10 +81,10 @@ func CommitWithTag(ctx context.Context, vmID string, tag *string) (*APIVmCommitR
 		}
 	}
 
-	// Set auth header using the same pattern as login.go
+	// Set auth header
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	// Execute the request using the same pattern as login.go
+	// Execute the request
 	client := &http.Client{Timeout: 60 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -133,8 +144,8 @@ var commitCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Creating commit for VM '%s'\n", vmID)
-		if tag != "" {
-			fmt.Printf("Tagging commit as: %s\n", tag)
+		if len(tags) > 0 {
+			fmt.Printf("Tags: %s\n", strings.Join(tags, ", "))
 		}
 
 		// Get VM details for alias information
@@ -147,19 +158,16 @@ var commitCmd = &cobra.Command{
 			vmInfo = utils.CreateVMInfoFromGetResponse(vmResponse.Data)
 		}
 
-		// Call our custom CommitWithTag function instead of the SDK's Commit method
-		var tagPtr *string
-		if tag != "" {
-			tagPtr = &tag
-		}
-
-		response, err := CommitWithTag(apiCtx, vmInfo.ID, tagPtr)
+		response, err := CommitWithTags(apiCtx, vmInfo.ID, tags)
 		if err != nil {
 			return fmt.Errorf("failed to commit VM '%s': %w", vmInfo.DisplayName, err)
 		}
 
 		fmt.Printf("Successfully committed VM '%s'\n", vmInfo.DisplayName)
 		fmt.Printf("Commit ID: %s\n", response.Data.ID)
+		if len(tags) > 0 {
+			fmt.Printf("Tags: %s\n", strings.Join(tags, ", "))
+		}
 
 		return nil
 	},
@@ -168,6 +176,6 @@ var commitCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(commitCmd)
 
-	// Define flags for the commit command
-	commitCmd.Flags().StringVarP(&tag, "tag", "t", "", "Tag for this commit")
+	// Define flags for the commit command - now supports multiple tags
+	commitCmd.Flags().StringSliceVarP(&tags, "tags", "t", []string{}, "Tags for this commit (can be specified multiple times)")
 }

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -69,9 +69,6 @@ var commitCmd = &cobra.Command{
 		fmt.Printf("Successfully committed VM '%s'\n", vmInfo.DisplayName)
 		fmt.Printf("Commit ID: %s\n", commitResult.ID)
 
-		// Note: Commit is now automatically stored in the database by the load balancer
-		// No local storage needed - commit history is available via 'vers log'
-
 		return nil
 	},
 }

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -97,6 +97,7 @@ var commitCmd = &cobra.Command{
 
 		fmt.Printf("Successfully committed VM '%s'\n", vmInfo.DisplayName)
 		fmt.Printf("Commit ID: %s\n", response.Data.CommitID)
+		fmt.Printf("Cluster ID: %s\n", response.Data.ClusterID)
 		if len(allTags) > 0 {
 			fmt.Printf("Tags: %s\n", strings.Join(allTags, ", "))
 		}

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -90,6 +90,7 @@ var commitCmd = &cobra.Command{
 				Tags: vers.F(allTags),
 			},
 		}
+
 		response, err := client.API.Vm.Commit(apiCtx, vmInfo.ID, body)
 		if err != nil {
 			return fmt.Errorf("failed to commit VM '%s': %w", vmInfo.DisplayName, err)
@@ -98,6 +99,7 @@ var commitCmd = &cobra.Command{
 		fmt.Printf("Successfully committed VM '%s'\n", vmInfo.DisplayName)
 		fmt.Printf("Commit ID: %s\n", response.Data.CommitID)
 		fmt.Printf("Cluster ID: %s\n", response.Data.ClusterID)
+		fmt.Printf("Host Architecture: %s\n", response.Data.HostArchitecture)
 		if len(allTags) > 0 {
 			fmt.Printf("Tags: %s\n", strings.Join(allTags, ", "))
 		}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -48,14 +48,15 @@ func NewLogStyles() LogStyles {
 
 // logCommitEntry represents commit information from the API
 type logCommitEntry struct {
-	ID        string   `json:"ID"`
-	Message   string   `json:"Message"`
-	Timestamp int64    `json:"Timestamp"`
-	Tags      []string `json:"Tags"`
-	Author    string   `json:"Author"`
-	VMID      string   `json:"VMID"`
-	Alias     string   `json:"Alias"`
-	ClusterID string   `json:"ClusterID"` // Added cluster ID
+	ID               string   `json:"ID"`
+	Message          string   `json:"Message"`
+	Timestamp        int64    `json:"Timestamp"`
+	Tags             []string `json:"Tags"`
+	Author           string   `json:"Author"`
+	VMID             string   `json:"VMID"`
+	Alias            string   `json:"Alias"`
+	ClusterID        string   `json:"ClusterID"`
+	HostArchitecture string   `json:"HostArchitecture"`
 }
 
 // commitResponse represents the API response structure
@@ -164,6 +165,9 @@ var logCmd = &cobra.Command{
 			fmt.Printf("%s %s\n", s.VMID.Render("VM:"), commit.VMID)
 			if commit.ClusterID != "" {
 				fmt.Printf("%s %s\n", s.Alias.Render("Cluster:"), commit.ClusterID)
+			}
+			if commit.HostArchitecture != "" {
+				fmt.Printf("%s %s\n", s.Alias.Render("Architecture:"), commit.HostArchitecture)
 			}
 
 			message := commit.Message

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -51,10 +51,11 @@ type logCommitEntry struct {
 	ID        string   `json:"ID"`
 	Message   string   `json:"Message"`
 	Timestamp int64    `json:"Timestamp"`
-	Tags      []string `json:"Tags"` // Changed from Tag string to Tags []string
+	Tags      []string `json:"Tags"`
 	Author    string   `json:"Author"`
 	VMID      string   `json:"VMID"`
 	Alias     string   `json:"Alias"`
+	ClusterID string   `json:"ClusterID"` // Added cluster ID
 }
 
 // commitResponse represents the API response structure
@@ -161,6 +162,9 @@ var logCmd = &cobra.Command{
 			fmt.Printf("%s %s\n", s.Author.Render("Author:"), commit.Author)
 			fmt.Printf("%s %s\n", s.Date.Render("Date:"), timestamp)
 			fmt.Printf("%s %s\n", s.VMID.Render("VM:"), commit.VMID)
+			if commit.ClusterID != "" {
+				fmt.Printf("%s %s\n", s.Alias.Render("Cluster:"), commit.ClusterID)
+			}
 
 			message := commit.Message
 			if message == "" {

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -47,13 +48,13 @@ func NewLogStyles() LogStyles {
 
 // logCommitEntry represents commit information from the API
 type logCommitEntry struct {
-	ID        string `json:"ID"`
-	Message   string `json:"Message"`
-	Timestamp int64  `json:"Timestamp"`
-	Tag       string `json:"Tag"`
-	Author    string `json:"Author"`
-	VMID      string `json:"VMID"`
-	Alias     string `json:"Alias"`
+	ID        string   `json:"ID"`
+	Message   string   `json:"Message"`
+	Timestamp int64    `json:"Timestamp"`
+	Tags      []string `json:"Tags"` // Changed from Tag string to Tags []string
+	Author    string   `json:"Author"`
+	VMID      string   `json:"VMID"`
+	Alias     string   `json:"Alias"`
 }
 
 // commitResponse represents the API response structure
@@ -138,9 +139,22 @@ var logCmd = &cobra.Command{
 
 			// Display commit info
 			fmt.Printf("%s %s\n", s.CommitID.Render("Commit:"), commit.ID)
-			if commit.Tag != "" {
-				fmt.Printf("%s\n", s.Tag.Render(commit.Tag))
+
+			// Display tags if they exist
+			if len(commit.Tags) > 0 {
+				// Filter out empty tags and join with commas
+				var nonEmptyTags []string
+				for _, tag := range commit.Tags {
+					if strings.TrimSpace(tag) != "" {
+						nonEmptyTags = append(nonEmptyTags, strings.TrimSpace(tag))
+					}
+				}
+				if len(nonEmptyTags) > 0 {
+					tagsStr := strings.Join(nonEmptyTags, ", ")
+					fmt.Printf("%s\n", s.Tag.Render(tagsStr))
+				}
 			}
+
 			if commit.Alias != "" && commit.Alias != commit.VMID {
 				fmt.Printf("%s %s\n", s.Alias.Render("Alias:"), commit.Alias)
 			}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -2,12 +2,7 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"sort"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -50,48 +45,20 @@ func NewLogStyles() LogStyles {
 	}
 }
 
-// readCommitLogFile reads commit information from a JSON log file
-func readCommitLogFile(versDir, vmID string) ([]logCommitEntry, error) {
-	logFile := filepath.Join(versDir, "logs", "commits", vmID+".json")
-
-	// Check if log file exists
-	if _, err := os.Stat(logFile); os.IsNotExist(err) {
-		return nil, nil // No error, just no log file
-	}
-
-	data, err := os.ReadFile(logFile)
-	if err != nil {
-		return nil, fmt.Errorf("error reading commit log: %w", err)
-	}
-
-	var commits []logCommitEntry
-	if err := json.Unmarshal(data, &commits); err != nil {
-		return nil, fmt.Errorf("error parsing commit log: %w", err)
-	}
-
-	return commits, nil
+// logCommitEntry represents commit information from the API
+type logCommitEntry struct {
+	ID        string `json:"ID"`
+	Message   string `json:"Message"`
+	Timestamp int64  `json:"Timestamp"`
+	Tag       string `json:"Tag"`
+	Author    string `json:"Author"`
+	VMID      string `json:"VMID"`
+	Alias     string `json:"Alias"`
 }
 
-// writeCommitLogFile writes commit information to a JSON log file
-func writeCommitLogFile(versDir string, vmID string, commits []logCommitEntry) error {
-	// Ensure logs/commits directory exists
-	commitsDir := filepath.Join(versDir, "logs", "commits")
-	if err := os.MkdirAll(commitsDir, 0755); err != nil {
-		return fmt.Errorf("error creating commits directory: %w", err)
-	}
-
-	logFile := filepath.Join(commitsDir, vmID+".json")
-
-	data, err := json.MarshalIndent(commits, "", "  ")
-	if err != nil {
-		return fmt.Errorf("error marshaling commit data: %w", err)
-	}
-
-	if err := os.WriteFile(logFile, data, 0644); err != nil {
-		return fmt.Errorf("error writing commit log: %w", err)
-	}
-
-	return nil
+// commitResponse represents the API response structure
+type commitResponse struct {
+	Commits []logCommitEntry `json:"commits"`
 }
 
 // logCmd represents the log command
@@ -104,12 +71,6 @@ var logCmd = &cobra.Command{
 		var vmID string
 		var vmInfo *utils.VMInfo
 		s := NewLogStyles()
-		versDir := ".vers"
-
-		// Check if .vers directory exists
-		if _, err := os.Stat(versDir); os.IsNotExist(err) {
-			return fmt.Errorf(".vers directory not found. Run 'vers init' first")
-		}
 
 		// Initialize SDK client and context
 		baseCtx := context.Background()
@@ -134,101 +95,37 @@ var logCmd = &cobra.Command{
 			vmID = vmInfo.ID
 		}
 
-		// Get VM details
+		// Get VM details if we don't have them
 		fmt.Println(s.NoData.Render("Fetching VM information..."))
 		if vmInfo == nil {
-			// We need to make the API call (HEAD case)
 			response, err := client.API.Vm.Get(apiCtx, vmID)
 			if err != nil {
 				return fmt.Errorf("failed to get VM information: %w", err)
 			}
-			// Create VMInfo from the response
 			vmInfo = utils.CreateVMInfoFromGetResponse(response.Data)
 		}
 
-		// First, try to read existing commit log (use VM ID for file operations)
-		commits, err := readCommitLogFile(versDir, vmInfo.ID)
+		// Fetch commit history from the API
+		fmt.Println(s.NoData.Render("Fetching commit history from server..."))
+
+		// Make API call to get commits for this VM
+		var commitResp commitResponse
+		err := client.Get(apiCtx, fmt.Sprintf("/api/vm/%s/commits", vmID), nil, &commitResp)
 		if err != nil {
-			commits = []logCommitEntry{}
-			fmt.Printf("Warning: %v\n", err)
+			// If API call fails, show a helpful message
+			fmt.Println(s.NoData.Render("No commit history found for this VM."))
+			fmt.Println(s.NoData.Render("Commits will appear here after you run 'vers commit'."))
+			return nil
 		}
 
-		// Check if we need to add a new commit record for this VM
-		foundCurrentVM := false
-		for _, commit := range commits {
-			if commit.VMID == vmInfo.ID {
-				foundCurrentVM = true
-				break
-			}
-		}
+		commits := commitResp.Commits
 
-		// If we don't have a commit record for this VM and we successfully got VM details,
-		// create a new commit info record using data from the API
-		if !foundCurrentVM {
-			// Create a simple message from VM display name
-			message := fmt.Sprintf("VM %s", vmInfo.DisplayName)
-
-			// Use State as additional info
-			if vmInfo.State != "" {
-				message = fmt.Sprintf("VM %s (%s)", vmInfo.DisplayName, vmInfo.State)
-			}
-
-			// Create commit info for this VM using API data
-			commitInfo := logCommitEntry{
-				ID:        fmt.Sprintf("c%s", strings.Replace(vmInfo.ID, "vm-", "", 1)),
-				Message:   message,
-				Timestamp: time.Now().Unix(), // Use current time as we don't have the exact commit time
-				Author:    "unknown",         // No author info from API
-				VMID:      vmInfo.ID,
-				Alias:     vmInfo.DisplayName,
-			}
-
-			// Add to our commits list
-			commits = append(commits, commitInfo)
-
-			// Save updated commits list
-			if err := writeCommitLogFile(versDir, vmInfo.ID, commits); err != nil {
-				fmt.Printf("Warning: Failed to update commit log: %v\n", err)
-			}
-		}
-
-		// Sort commits by timestamp (newest first)
-		sort.Slice(commits, func(i, j int) bool {
-			return commits[i].Timestamp > commits[j].Timestamp
-		})
-
-		// If no commits found, use mock data
+		// If no commits found, show helpful message
 		if len(commits) == 0 {
-			fmt.Println(s.NoData.Render("No commit history found. Using mock data for demonstration."))
-
-			// Mock data for demonstration
-			commits = []logCommitEntry{
-				{
-					ID:        "c123456789abcdef",
-					Message:   "Initial commit",
-					Timestamp: time.Now().Add(-48 * time.Hour).Unix(),
-					Author:    "user@example.com",
-					VMID:      "vm-ancestor-123",
-					Alias:     "initial-vm",
-				},
-				{
-					ID:        "c234567890abcdef",
-					Message:   "Add feature X",
-					Timestamp: time.Now().Add(-24 * time.Hour).Unix(),
-					Tag:       "v0.1.0",
-					Author:    "user@example.com",
-					VMID:      "vm-parent-456",
-					Alias:     "feature-x",
-				},
-				{
-					ID:        "c345678901abcdef",
-					Message:   "Fix bug in feature X",
-					Timestamp: time.Now().Unix(),
-					Author:    "user@example.com",
-					VMID:      vmInfo.ID,
-					Alias:     vmInfo.DisplayName,
-				},
-			}
+			fmt.Printf("\n%s\n\n", s.Header.Render(fmt.Sprintf("Commit History for VM: %s", vmInfo.DisplayName)))
+			fmt.Println(s.NoData.Render("No commits found for this VM."))
+			fmt.Println(s.NoData.Render("Run 'vers commit' to create your first commit."))
+			return nil
 		}
 
 		// Display the VM info header
@@ -244,7 +141,7 @@ var logCmd = &cobra.Command{
 			if commit.Tag != "" {
 				fmt.Printf("%s\n", s.Tag.Render(commit.Tag))
 			}
-			if commit.Alias != "" {
+			if commit.Alias != "" && commit.Alias != commit.VMID {
 				fmt.Printf("%s %s\n", s.Alias.Render("Alias:"), commit.Alias)
 			}
 			fmt.Printf("%s %s\n", s.Author.Render("Author:"), commit.Author)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16.0.20250714174642-fcf015218aaa
+	github.com/hdresearch/vers-sdk-go v0.1.0-alpha.17
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/term v0.32.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16
+	github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16.0.20250714174642-fcf015218aaa
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/term v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,12 @@ github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a/go.mod 
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16 h1:VxIsQDP1LfSjK1Ydbwc3jdzon+S4ZuoRX6oZ7tzcVD8=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16.0.20250714174642-fcf015218aaa h1:d0pvsijonNFOVUejHJOCSEXHvUZ0mcmA3/rOwVm1Wwk=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16.0.20250714174642-fcf015218aaa/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.17 h1:7tt9GF3+qa5h4eF1S+TdVCRG0+DNXtN4wFioIuFJAQo=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.17/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNE
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16 h1:VxIsQDP1LfSjK1Ydbwc3jdzon+S4ZuoRX6oZ7tzcVD8=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16.0.20250714174642-fcf015218aaa h1:d0pvsijonNFOVUejHJOCSEXHvUZ0mcmA3/rOwVm1Wwk=
+github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16.0.20250714174642-fcf015218aaa/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a/go.mod 
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16 h1:VxIsQDP1LfSjK1Ydbwc3jdzon+S4ZuoRX6oZ7tzcVD8=
-github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16.0.20250714174642-fcf015218aaa h1:d0pvsijonNFOVUejHJOCSEXHvUZ0mcmA3/rOwVm1Wwk=
 github.com/hdresearch/vers-sdk-go v0.1.0-alpha.16.0.20250714174642-fcf015218aaa/go.mod h1:DNFFMmYF8qOcTD2LPejHXQCxDvSWkmej4JobkpPlcWs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/utils/vm.go
+++ b/internal/utils/vm.go
@@ -12,7 +12,6 @@ type VMInfo struct {
 	ID          string
 	DisplayName string
 	State       string
-	ClusterID   string
 }
 
 // ResolveVMIdentifier takes a VM ID or alias and returns the VM ID and display info
@@ -33,7 +32,6 @@ func ResolveVMIdentifier(ctx context.Context, client *vers.Client, identifier st
 		ID:          vm.ID,
 		DisplayName: displayName,
 		State:       string(vm.State),
-		ClusterID:   vm.ClusterID,
 	}, nil
 }
 
@@ -48,7 +46,6 @@ func CreateVMInfoFromGetResponse(vm vers.APIVmGetResponseData) *VMInfo {
 		ID:          vm.ID,
 		DisplayName: displayName,
 		State:       string(vm.State),
-		ClusterID:   vm.ClusterID,
 	}
 }
 
@@ -63,6 +60,5 @@ func CreateVMInfoFromUpdateResponse(vm vers.APIVmUpdateResponseData) *VMInfo {
 		ID:          vm.ID,
 		DisplayName: displayName,
 		State:       string(vm.State),
-		ClusterID:   vm.ClusterID,
 	}
 }

--- a/internal/utils/vm.go
+++ b/internal/utils/vm.go
@@ -12,6 +12,7 @@ type VMInfo struct {
 	ID          string
 	DisplayName string
 	State       string
+	ClusterID   string
 }
 
 // ResolveVMIdentifier takes a VM ID or alias and returns the VM ID and display info
@@ -32,6 +33,7 @@ func ResolveVMIdentifier(ctx context.Context, client *vers.Client, identifier st
 		ID:          vm.ID,
 		DisplayName: displayName,
 		State:       string(vm.State),
+		ClusterID:   vm.ClusterID,
 	}, nil
 }
 
@@ -46,6 +48,7 @@ func CreateVMInfoFromGetResponse(vm vers.APIVmGetResponseData) *VMInfo {
 		ID:          vm.ID,
 		DisplayName: displayName,
 		State:       string(vm.State),
+		ClusterID:   vm.ClusterID,
 	}
 }
 
@@ -60,5 +63,6 @@ func CreateVMInfoFromUpdateResponse(vm vers.APIVmUpdateResponseData) *VMInfo {
 		ID:          vm.ID,
 		DisplayName: displayName,
 		State:       string(vm.State),
+		ClusterID:   vm.ClusterID,
 	}
 }


### PR DESCRIPTION
This PR is a companion to PR#16 in vers-lb (https://github.com/hdresearch/vers-lb/pull/16). Since we now have a database to store (pointers to) machine image commits, it is no longer necessary for such pointers to be stored locally.

This PR also addresses issue #84 ; since the DB now exists, `vers log` does not need to be a mock feature.

EDIT: Ready for testing. Be sure to run PR#16 on `vers-lb` with two environmental variables (`DEV_TARGET_NODE` set to the URL for your node, and `DEV_TARGET_NODE_API_KEY` set to the API key you sent me). `vers commit` and `vers log` should correctly work (and `vers commit` should work with the various tagging features added), with cluster ID and host architecture stored.