### PR TITLE
Removing VM IP addresses from user output

### DIFF
--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -76,7 +76,6 @@ var branchCmd = &cobra.Command{
 			fmt.Printf(s.ListItem.Render(s.InfoLabel.Render("Alias")+": "+s.BranchName.Render(branchInfo.Alias)) + "\n")
 		}
 
-		fmt.Printf(s.ListItem.Render(s.InfoLabel.Render("IP Address")+": "+s.CurrentState.Render(branchInfo.IPAddress)) + "\n")
 		fmt.Printf(s.ListItem.Render(s.InfoLabel.Render("State")+": "+s.CurrentState.Render(string(branchInfo.State))) + "\n\n")
 
 		// Check if user wants to switch to the new VM

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -179,9 +179,6 @@ func printVMTreeFromListData(vms []vers.VmDto, currentVMID, prefix string, isLas
 	}
 
 	vmInfo := fmt.Sprintf("%s %s", stateStyle.Render(stateSymbol), styles.BaseTextStyle.Render(displayName))
-	if currentVM.IPAddress != "" {
-		vmInfo += fmt.Sprintf(" (%s)", styles.MutedTextStyle.Render(currentVM.IPAddress))
-	}
 
 	finalStyle := styles.NormalListItemStyle
 	if currentVM.ID == headVMID {


### PR DESCRIPTION
This removes cases where a VM IP (only reachable from within the machine anyway) is shown to the user as part of the CLI output. Addresses issue #83.