### PR TITLE
Improvements to `kill.go`

### DIFF
--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -36,13 +36,27 @@ Examples:
   vers kill -y -r vm-with-children       # Skip confirmations AND delete children
   vers kill -a -y                        # Delete ALL clusters without confirmation`,
 	Args: func(cmd *cobra.Command, args []string) error {
-		if killAll {
-			if len(args) > 0 {
-				return fmt.Errorf("cannot specify target when using --all flag")
-			}
-			return nil
+		// -a and -c are mutually exclusive
+		if killAll && isCluster {
+			return fmt.Errorf("cannot use --all and --cluster together")
 		}
-		// Allow 0 or more arguments (0 means use HEAD)
+
+		// -a requires no arguments
+		if killAll && len(args) > 0 {
+			return fmt.Errorf("cannot specify targets when using --all")
+		}
+
+		// -c requires at least one argument
+		if isCluster && !killAll && len(args) == 0 {
+			return fmt.Errorf("--cluster requires at least one cluster identifier")
+		}
+
+		// -r only makes sense for VMs, not clusters
+		if recursive && isCluster {
+			return fmt.Errorf("--recursive only applies to VMs, not clusters")
+		}
+
+		// Allow 0 or more arguments for VM operations (0 means use HEAD)
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/deletion/cluster_deletion_processor.go
+++ b/internal/deletion/cluster_deletion_processor.go
@@ -10,18 +10,20 @@ import (
 )
 
 type ClusterDeletionProcessor struct {
-	client *vers.Client
-	styles *styles.KillStyles
-	ctx    context.Context
-	force  bool
+	client           *vers.Client
+	styles           *styles.KillStyles
+	ctx              context.Context
+	skipConfirmation bool
+	recursive        bool
 }
 
-func NewClusterDeletionProcessor(client *vers.Client, s *styles.KillStyles, ctx context.Context, force bool) *ClusterDeletionProcessor {
+func NewClusterDeletionProcessor(client *vers.Client, s *styles.KillStyles, ctx context.Context, skipConfirmation, recursive bool) *ClusterDeletionProcessor {
 	return &ClusterDeletionProcessor{
-		client: client,
-		styles: s,
-		ctx:    ctx,
-		force:  force,
+		client:           client,
+		styles:           s,
+		ctx:              ctx,
+		skipConfirmation: skipConfirmation,
+		recursive:        recursive,
 	}
 }
 
@@ -86,8 +88,8 @@ func (p *ClusterDeletionProcessor) DeleteMultipleClusters(identifiers []string) 
 // DeleteSingleCluster deletes a single cluster with pre-resolved info
 // Returns the list of deleted VM IDs and any error
 func (p *ClusterDeletionProcessor) DeleteSingleCluster(clusterInfo *utils.ClusterInfo, currentIndex, totalCount int) ([]string, error) {
-	// Get confirmation if not forced
-	if !p.force {
+	// Get confirmation if not skipping confirmations
+	if !p.skipConfirmation {
 		if !utils.ConfirmClusterDeletion(clusterInfo.DisplayName, clusterInfo.VmCount, p.styles) {
 			utils.OperationCancelled(p.styles)
 			return nil, fmt.Errorf("operation cancelled by user")
@@ -101,7 +103,8 @@ func (p *ClusterDeletionProcessor) DeleteSingleCluster(clusterInfo *utils.Cluste
 	}
 
 	// Show progress and perform deletion
-	return utils.HandleDeletionResult(currentIndex, totalCount, "Deleting cluster", clusterInfo.DisplayName, func() ([]string, error) {
+	action := p.getDeletionAction()
+	return utils.HandleDeletionResult(currentIndex, totalCount, action, clusterInfo.DisplayName, func() ([]string, error) {
 		return p.deleteCluster(clusterInfo.ID)
 	}, p.styles)
 }
@@ -126,7 +129,7 @@ func (p *ClusterDeletionProcessor) DeleteAllClusters() error {
 		clusterInfos = append(clusterInfos, clusterInfo)
 	}
 
-	if !p.force && !p.confirmDeleteAllWithInfo(clusterInfos) {
+	if !p.skipConfirmation && !p.confirmDeleteAllWithInfo(clusterInfos) {
 		utils.NoDataFound("Operation cancelled - input did not match 'DELETE ALL'", p.styles)
 		return nil
 	}
@@ -194,6 +197,18 @@ func (p *ClusterDeletionProcessor) confirmDeleteAllWithInfo(clusterInfos []*util
 	fmt.Println()
 
 	return utils.AskSpecialConfirmation("DELETE ALL", p.styles)
+}
+
+// getDeletionAction returns the appropriate action description based on flags
+func (p *ClusterDeletionProcessor) getDeletionAction() string {
+	if p.skipConfirmation && p.recursive {
+		return "Force deleting cluster (recursive)"
+	} else if p.skipConfirmation {
+		return "Force deleting cluster"
+	} else if p.recursive {
+		return "Deleting cluster (recursive)"
+	}
+	return "Deleting cluster"
 }
 
 func (p *ClusterDeletionProcessor) deleteCluster(clusterID string) ([]string, error) {


### PR DESCRIPTION
The first thing that this PR does is split the `--force` tag (which both skips confirmations and recursively deletes children) into two tags, `--y` (which skips confirmations) and `--r` (which deletes children recursively). Further improvements/changes to the kill behavior derived from the current issue list will also be consolidated at this PR.

Secondly, this also introduces a special error message for the scenario of the backend returning error code 409 when a user tries to kill a VM with children, explaining the error the user has made.