### PR TITLE
When connecting to localhost or 0.0.0.0, use a local connection string instead of a public one

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -80,12 +80,12 @@ var connectCmd = &cobra.Command{
 		sshHost := versHost
 		sshPort := fmt.Sprintf("%d", vm.NetworkInfo.SSHPort)
 		if utils.HostIsLocal(versHost) {
-			sshHost = vm.NetworkInfo.GuestIP
+			sshHost = vm.IPAddress
 			sshPort = "22"
 		}
 
 		// Debug info about connection
-		fmt.Printf(s.HeadStatus.Render("Connecting to %s on port %d\n"), sshHost, sshPort)
+		fmt.Printf(s.HeadStatus.Render("Connecting to %s on port %s\n"), sshHost, sshPort)
 
 		sshCmd := exec.Command("ssh",
 			fmt.Sprintf("root@%s", sshHost),

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -71,9 +71,6 @@ var connectCmd = &cobra.Command{
 
 		fmt.Printf(s.HeadStatus.Render("Connecting to VM %s..."), vmInfo.DisplayName)
 
-		// Debug info about connection
-		fmt.Printf(s.HeadStatus.Render("Connecting to %s on port %d\n"), versHost, vm.NetworkInfo.SSHPort)
-
 		keyPath, err := auth.GetOrCreateSSHKey(vmInfo.ID, client, apiCtx)
 		if err != nil {
 			return fmt.Errorf("failed to get or create SSH key: %w", err)
@@ -86,6 +83,9 @@ var connectCmd = &cobra.Command{
 			sshHost = vm.NetworkInfo.GuestIP
 			sshPort = "22"
 		}
+
+		// Debug info about connection
+		fmt.Printf(s.HeadStatus.Render("Connecting to %s on port %d\n"), sshHost, sshPort)
 
 		sshCmd := exec.Command("ssh",
 			fmt.Sprintf("root@%s", sshHost),

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -108,7 +108,7 @@ var executeCmd = &cobra.Command{
 		sshHost := versHost
 		sshPort := fmt.Sprintf("%d", vm.NetworkInfo.SSHPort)
 		if utils.HostIsLocal(versHost) {
-			sshHost = vm.NetworkInfo.GuestIP
+			sshHost = vm.IPAddress
 			sshPort = "22"
 		}
 

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -77,6 +77,16 @@ var executeCmd = &cobra.Command{
 			commandArgs = args
 		}
 
+		// If no node IP in headers, use default vers URL
+		versHost := nodeIP
+		if strings.TrimSpace(versHost) == "" {
+			versUrl, err := auth.GetVersUrl()
+			if err != nil {
+				return err
+			}
+			versHost = versUrl.Hostname()
+		}
+
 		// Join the command arguments
 		commandStr = strings.Join(commandArgs, " ")
 
@@ -94,10 +104,18 @@ var executeCmd = &cobra.Command{
 			return fmt.Errorf("failed to get or create SSH key: %w", err)
 		}
 
+		// If we're connecting to a local machine, then use a connection string with local VM IPs. Else, use the public (DNAT'd) connection string
+		sshHost := versHost
+		sshPort := fmt.Sprintf("%d", vm.NetworkInfo.SSHPort)
+		if utils.HostIsLocal(versHost) {
+			sshHost = vm.NetworkInfo.GuestIP
+			sshPort = "22"
+		}
+
 		// Create the SSH command with the provided command string
 		sshCmd := exec.Command("ssh",
-			fmt.Sprintf("root@%s", nodeIP),
-			"-p", fmt.Sprintf("%d", vm.NetworkInfo.SSHPort),
+			fmt.Sprintf("root@%s", sshHost),
+			"-p", sshPort,
 			"-o", "StrictHostKeyChecking=no",
 			"-o", "UserKnownHostsFile=/dev/null", // Avoid host key prompts
 			"-o", "IdentitiesOnly=yes", // Only use the specified identity file

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -21,7 +21,7 @@ func validateAPIKey(apiKey string) error {
 	if err != nil {
 		return fmt.Errorf("error getting API URL: %w", err)
 	}
-	validateURL := baseURL + "/api/validate"
+	validateEndpoint := baseURL.String() + "/api/validate"
 
 	payload := map[string]string{
 		"api_key": apiKey,
@@ -32,7 +32,7 @@ func validateAPIKey(apiKey string) error {
 		return fmt.Errorf("error preparing validation request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", validateURL, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest("POST", validateEndpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return fmt.Errorf("error creating validation request: %w", err)
 	}

--- a/internal/utils/network.go
+++ b/internal/utils/network.go
@@ -33,18 +33,26 @@ func GetVmAndNodeIP(ctx context.Context, client *vers.Client, vmID string) (vers
 	nodeIP := rawResponse.Header.Get("X-Node-IP")
 
 	// Use the node IP from headers or fallback to env override, and then static load balancer host
-	var hostIP string
+	var versHost string
 	if nodeIP != "" {
-		hostIP = nodeIP
+		versHost = nodeIP
 	} else {
-		hostIP, err = auth.GetVersUrlHost()
+		versUrl, err := auth.GetVersUrl()
 		if err != nil {
 			return vers.APIVmGetResponseData{}, "", fmt.Errorf("failed to get host IP: %w", err)
 		}
+
+		versHost = versUrl.Hostname()
 		if os.Getenv("VERS_DEBUG") == "true" {
-			fmt.Printf("[DEBUG] No node IP in headers, using fallback: %s\n", hostIP)
+			fmt.Printf("[DEBUG] No node IP in headers, using fallback: %s\n", versHost)
 		}
 	}
 
-	return response.Data, hostIP, nil
+	return response.Data, versHost, nil
+}
+
+func HostIsLocal(hostName string) bool {
+	// RFC 5735
+	const LOOPBACK = "127.0.0.1"
+	return hostName == "localhost" || hostName == "0.0.0.0" || hostName == LOOPBACK
 }


### PR DESCRIPTION
Demonstration attached, shown running from my dev node, as well as from my own computer (demonstrating that the old functionality should not be affected.)
<img width="846" height="1014" alt="Screenshot 2025-07-16 at 11 26 19 AM" src="https://github.com/user-attachments/assets/6be2e0b8-2670-47d5-9fe0-59a4ef3452e1" />
<img width="846" height="1014" alt="Screenshot 2025-07-16 at 11 29 09 AM" src="https://github.com/user-attachments/assets/804aeea5-4688-41f9-8259-a5a7fad0d621" />
