### PR TITLE
Changing log.go to history.go

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -66,7 +66,7 @@ type commitResponse struct {
 
 // logCmd represents the log command
 var logCmd = &cobra.Command{
-	Use:   "log [vm-id|alias]",
+	Use:   "history [vm-id|alias]",
 	Short: "Display commit history",
 	Long:  `Shows the commit history for the current VM or a specified VM ID or alias.`,
 	Args:  cobra.MaximumNArgs(1),


### PR DESCRIPTION
The command `vers log` has been changed to `vers history` in this PR.