### PR TITLE
Fixes upgrade command returning 404 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 NAME ?= vers-cli
 DESCRIPTION ?= A CLI tool for version management
 AUTHOR ?= Tynan Daly
-REPOSITORY ?= https://github.com/tynandaly/vers-cli
+REPOSITORY ?= https://github.com/hdresearch/vers-cli
 LICENSE ?= MIT
 
 # Build flags

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ var (
 	Name        = "vers-cli"
 	Description = "A CLI tool for version management"
 	Author      = "the VERS team"
-	Repository  = "https://github.com/tynandaly/vers-cli"
+	Repository  = "https://github.com/hdresearch/vers-cli"
 	License     = "MIT"
 )
 


### PR DESCRIPTION
The issue here is that the URL of the project was being constructed incorrectly in the Makefile -- it is at `github.com/hdresearch/vers-cli`, not `github.com/tynandaly/vers-cli`. `vers upgrade` appears to work correctly after this change is applied (though note that it won't _work_ work, at least on my machine, unless you run `sudo vers upgrade`, but I think this is what we want).

Addresses issue #96 .

EDIT: Possible note to be made here that this error will return if we ever choose to rename the `hdresearch` organization on GitHub, which I think we intend to do eventually. We'll need to remember to update this code in that case.