### PR TITLE
fix branch command formatting

### DIFF
--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -90,7 +90,8 @@ var branchCmd = &cobra.Command{
 				if displayName == "" {
 					displayName = branchInfo.ID
 				}
-				fmt.Printf(s.Success.Render("✓ HEAD now points to: ") + s.BranchName.Render(displayName) + "\n")
+				successStyle := s.Success.Padding(0, 0)
+				fmt.Printf(successStyle.Render("✓ HEAD now points to: ") + s.VMID.Render(displayName) + "\n")
 			}
 		} else {
 			// Show tip about switching


### PR DESCRIPTION
Previously branch command outputs looked like this:
``` ➜  vers-cli git:(main) vers branch -c
Using current HEAD VM: e7b1d109-178f-4ac1-9ae7-caa71f4e82bb

Creating new VM from: e7b1d109-178f-4ac1-9ae7-caa71f4e82bb


✓ New VM created successfully!

 New VM details:

   VM ID       : 294d75bd-3a14-4f3e-9fe9-1b8fcb960a57
   State       : Running


✓ HEAD now points to:
                      294d75bd-3a14-4f3e-9fe9-1b8fcb960a57
```
                      
Notice how the last line is broken up?

Now it looks like this:

```
➜  vers-cli git:(main) ✗ ./bin/vers branch -c
Using current HEAD VM: a5540f0a-4d4f-4a0a-9af4-10538a2905bd

Creating new VM from: a5540f0a-4d4f-4a0a-9af4-10538a2905bd


✓ New VM created successfully!

 New VM details:

   VM ID       : 301d6458-1ded-43b1-8786-e718f587a7cb
   State       : Running

✓ HEAD now points to: 301d6458-1ded-43b1-8786-e718f587a7cb
```