### PR TITLE
Ty/higher contrast vmid

### DIFF
--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -90,7 +90,8 @@ var branchCmd = &cobra.Command{
 				if displayName == "" {
 					displayName = branchInfo.ID
 				}
-				fmt.Printf(s.Success.Render("✓ HEAD now points to: ") + s.BranchName.Render(displayName) + "\n")
+				successStyle := s.Success.Padding(0, 0)
+				fmt.Printf(successStyle.Render("✓ HEAD now points to: ") + s.VMID.Render(displayName) + "\n")
 			}
 		} else {
 			// Show tip about switching

--- a/styles/themes.go
+++ b/styles/themes.go
@@ -48,5 +48,6 @@ var (
 			Foreground(Primary)
 
 	VmIDStyle = BaseTextStyle.
-			Background(TerminalSilver)
+		// Background(TerminalSilver).
+		Foreground(TerminalLime)
 )


### PR DESCRIPTION
I expect this one to be a tad controversial. 

Right now, the VMID renders a white text on a gray background. I've been finding this hard to read. This PR changes is to be a lime green text with no background. 

Feel free to say no if this offends aesthetic sensibilities. But we should sit down next week and pencil out a design language if we don't already have one floating around somewhere.