### PR TITLE
Wrap SSH commands in TLS so we can route based on SNI

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -98,7 +98,7 @@ var connectCmd = &cobra.Command{
 			"-o", "IdentitiesOnly=yes", // Only use the specified identity file
 			"-o", "PreferredAuthentications=publickey", // Only attempt public key authentication
 			"-i", keyPath, // Use the persistent key file
-			"api.vers.sh")
+		)
 
 		sshCmd.Stdout = os.Stdout
 		sshCmd.Stderr = os.Stderr

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -147,7 +147,6 @@ Examples:
 			"-o", "PreferredAuthentications=publickey",
 			"-o", "LogLevel=ERROR",
 			"-i", keyPath,
-			"api.vers.sh",
 		}
 
 		// Add recursive flag if enabled

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -125,7 +125,6 @@ var executeCmd = &cobra.Command{
 			"-o", "PreferredAuthentications=publickey", // Only attempt public key authentication
 			"-o", "LogLevel=ERROR", // Add this line to suppress warnings
 			"-i", keyPath, // Use the persistent key file
-			"api.vers.sh",
 			commandStr) // Add the command to execute
 
 		// Connect command output to current terminal


### PR DESCRIPTION
Don't merge yet.

# Current State

The CLI hits the API to get the Node's public IP address via a header:

https://github.com/hdresearch/vers-cli/blob/main/internal/utils/network.go#L17

And then makes a direct SSH connection to that public IP address, which is then NAT'ed and routed over a veth pair to the VM.

# Future State

With the network upgrades in progress that will change. All ingress should route through the proxy. For many protocols this is reasonably strait forward, as we can use TLS's [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) to know the hostname of the desired VM. SSH however uses its own protocol, which doesn't support SNI, so we don't know which VM to proxy the traffic to.

That leaves several a few options.

1. We might be able to inspect the SSH traffic and infer the destination host. It looks like some [other projects](https://github.com/yrutschle/sslh) may do that. But the [SSH protocol](https://www.rfc-editor.org/rfc/rfc4253) is involved, and it isn't clear if we could get enough information to route between hosts. 

2. We could use something like a [jump host](https://en.wikipedia.org/wiki/Jump_server), there is even some interesting [prior](https://warpgate.null.page/) [art](https://github.com/warp-tech/warpgate) there. But managing and securing that would be complicated. We would also effectively be a (trusted) man in the middle.

3.  And finally we can wrap the SSH connection in something else (Websocket, TLS, etc) that _does_ offer SNI. I've gone with this route.

The current code https://github.com/hdresearch/vers-cli/blob/main/cmd/connect.go#L52 appears to default to api.vers.sh if it doesn't receive the `X-Node-IP` header. The new proxy won't set that header, causing the CLI to fallback to sending all traffic to it. In this PR we then use SSH's `ProxyCommand` to wrap the connection in TLS, and set the correct SNI, which the proxy will then be able to use to route the traffic directly to the correct VM.

# Notes
- This needs integration testing with the new proxy prior to merging.
- The [cmd](https://github.com/hdresearch/vers-cli/blob/js%2Ftunnel-ssh/cmd/) code looks repetitive, I recommend we [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) it up
-  In the long term we probably want to take a different approach than exec'ing out to SSH. Something that could support windows... but that is beyond this PR's scope.

And I barely know go, so I may have done something dumb.