### PR TITLE
(Hotfix) Allow `vers branch` to accept a commit ID

### DIFF
--- a/internal/handlers/branch.go
+++ b/internal/handlers/branch.go
@@ -19,7 +19,7 @@ func HandleBranch(ctx context.Context, a *app.App, r BranchReq) (presenters.Bran
 	res := presenters.BranchView{}
 
 	// Resolve source VM id
-	var vmID string
+	vmID := r.Target
 	var vmInfo *utils.VMInfo
 	var err error
 	if r.Target == "" {
@@ -32,12 +32,12 @@ func HandleBranch(ctx context.Context, a *app.App, r BranchReq) (presenters.Bran
 		res.FromName = vmID
 	} else {
 		vmInfo, err = utils.ResolveVMIdentifier(ctx, a.Client, r.Target)
-		if err != nil {
-			return res, fmt.Errorf("failed to find VM: %w", err)
+		// If VM cannot be resolved, this request may be targeting a commit ID instead
+		if err == nil {
+			vmID = vmInfo.ID
+			res.FromID = vmID
+			res.FromName = vmInfo.DisplayName
 		}
-		vmID = vmInfo.ID
-		res.FromID = vmID
-		res.FromName = vmInfo.DisplayName
 	}
 
 	// Note: Alias parameter no longer supported in new SDK


### PR DESCRIPTION
Note that this PR is just the minimum change necessary to make `vers branch` work with the upcoming update allowing the branch endpoint to accept either a commit or VM ID. There is a lot of unnecessary logic still present in the CLI that can be ripped out re: aliases, and there is definitely documentation that should be adjusted to accommodate this change.