### PR TITLE
Reconnect when ssh drops

### DIFF
--- a/internal/handlers/connect.go
+++ b/internal/handlers/connect.go
@@ -6,12 +6,15 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/hdresearch/vers-cli/internal/app"
 	"github.com/hdresearch/vers-cli/internal/presenters"
 	vmSvc "github.com/hdresearch/vers-cli/internal/services/vm"
 	sshutil "github.com/hdresearch/vers-cli/internal/ssh"
 	"github.com/hdresearch/vers-cli/internal/utils"
+	"github.com/hdresearch/vers-cli/styles"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/term"
 )
 
@@ -76,21 +79,66 @@ func HandleConnect(ctx context.Context, a *app.App, r ConnectReq) (presenters.Co
 		}
 	}
 
-	// Use native SSH client
+	// Use native SSH client with automatic reconnection on dropped connections
 	client := sshutil.NewClient(sshHost, info.KeyPath)
-	err = client.Interactive(ctx, stdin, a.IO.Out, a.IO.Err)
 
-	// Always restore terminal state after SSH exits, regardless of how it exited
-	if oldState != nil {
-		_ = term.Restore(fd, oldState)
-	}
+	const maxReconnectAttempts = 5
+	const initialBackoff = 1 * time.Second
+	const maxBackoff = 10 * time.Second
 
-	if err != nil {
-		// Context cancellation is not an error for interactive sessions
+	s := styles.NewStatusStyles()
+
+	for attempt := 0; ; attempt++ {
+		err = client.Interactive(ctx, stdin, a.IO.Out, a.IO.Err)
+
+		// Always restore terminal state after SSH exits
+		if oldState != nil {
+			_ = term.Restore(fd, oldState)
+		}
+
+		// Clean exit (user typed exit/logout) — done
+		if err == nil {
+			return view, nil
+		}
+
+		// Context cancelled (e.g. vers process killed) — done
 		if ctx.Err() != nil {
 			return view, nil
 		}
-		return view, fmt.Errorf("SSH session failed: %w", err)
+
+		// User's shell exited with a status code — done (not a dropped connection)
+		if _, ok := err.(*ssh.ExitError); ok {
+			return view, nil
+		}
+
+		// Connection dropped — attempt reconnect
+		if attempt >= maxReconnectAttempts {
+			return view, fmt.Errorf("SSH connection lost after %d reconnection attempts: %w", maxReconnectAttempts, err)
+		}
+
+		backoff := initialBackoff * time.Duration(1<<uint(attempt))
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+
+		fmt.Fprintf(a.IO.Out, "\r\n%s\r\n", s.HeadStatus.Render(
+			fmt.Sprintf("Connection lost. Reconnecting (attempt %d/%d)...", attempt+1, maxReconnectAttempts),
+		))
+		if f, ok := a.IO.Out.(*os.File); ok {
+			f.Sync()
+		}
+
+		select {
+		case <-ctx.Done():
+			return view, nil
+		case <-time.After(backoff):
+		}
+
+		// Re-enter raw mode for next interactive session
+		if oldState != nil {
+			if _, rawErr := term.MakeRaw(fd); rawErr != nil {
+				return view, fmt.Errorf("failed to restore raw terminal for reconnect: %w", rawErr)
+			}
+		}
 	}
-	return view, nil
 }


### PR DESCRIPTION
## Description

SSH dropping on the server-side results in an error state whereas attempting to re-connect makes sense for convenience 

My session result:

```
$ vers connect UUID_FOR_VM_HERE
Fetching SSH key from API...
✓ SSH key cached
                                                        
Connecting to VM UUDI_FOR_VM_HERE...
                                                        
Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 6.1.141 x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

This system has been minimized by removing packages and content that are
not required on a system that users do not log into.

To restore this content, you can run the 'unminimize' command.
root@hdr:~# # Check the OS
cat /etc/os-release
PRETTY_NAME="Ubuntu 24.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.2 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo
root@hdr:~# which python3 node
/usr/bin/python3
root@hdr:~# echo "hello world" >> teError: SSH session failed: wait: remote command exited without exit status or exit signal
Usage:
  vers connect [vm-id|alias] [flags]

Flags:
  -h, --help          help for connect
      --host string   Specify the host IP to connect to (overrides default)

Global Flags:
  -v, --verbose   Enable verbose output
```

## AI Summary

- Automatically reconnects SSH sessions when the connection drops instead of exiting with an error
- Uses exponential backoff (1s to 10s) with up to 5 reconnection attempts
- Distinguishes between intentional exits (user logout, exit codes, context cancellation) and dropped connections