### PR TITLE
feat: derive SSH VM domain from VERS_URL for staging support

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -174,4 +174,21 @@ func GetClientOptions() ([]option.RequestOption, error) {
 	return clientOptions, nil
 }
 
+// GetVMDomain derives the VM SSH domain from the configured VERS_URL.
+// For example:
+//   - "https://api.vers.sh"         -> "vm.vers.sh"
+//   - "https://api.staging.vers.sh" -> "vm.staging.vers.sh"
+func GetVMDomain() string {
+	versUrl, err := GetVersUrl()
+	if err != nil {
+		return "vm.vers.sh" // safe fallback to production
+	}
+	host := versUrl.Hostname()
+	if strings.HasPrefix(host, "api.") {
+		return "vm." + strings.TrimPrefix(host, "api.")
+	}
+	// Fallback: assume production domain
+	return "vm.vers.sh"
+}
+
 // Backward-compatibility checks removed; the CLI only targets DEFAULT_VERS_URL (or VERS_URL override).

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetVMDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		versURL  string
+		expected string
+	}{
+		{"production default", "", "vm.vers.sh"},
+		{"production explicit", "https://api.vers.sh", "vm.vers.sh"},
+		{"staging", "https://api.staging.vers.sh", "vm.staging.vers.sh"},
+		{"custom", "https://api.dev.example.com", "vm.dev.example.com"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.versURL != "" {
+				os.Setenv("VERS_URL", tc.versURL)
+				defer os.Unsetenv("VERS_URL")
+			} else {
+				os.Unsetenv("VERS_URL")
+			}
+
+			got := GetVMDomain()
+			if got != tc.expected {
+				t.Errorf("GetVMDomain() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/handlers/connect.go
+++ b/internal/handlers/connect.go
@@ -84,7 +84,7 @@ func HandleConnect(ctx context.Context, a *app.App, r ConnectReq) (presenters.Co
 	}
 
 	vmInfo := utils.CreateVMInfoFromVM(*info.VM)
-	// Use VM ID as host for SSH-over-TLS (will be formatted as {vm-id}.vm.vers.sh)
+	// Use VM ID as host for SSH-over-TLS (will be formatted as {vm-id}.{vmDomain})
 	sshHost := info.Host
 	sshPort := "443" // SSH-over-TLS uses port 443
 	view.LocalRoute = true
@@ -123,7 +123,7 @@ func HandleConnect(ctx context.Context, a *app.App, r ConnectReq) (presenters.Co
 	}
 
 	// Use native SSH client with automatic reconnection on dropped connections
-	client := sshutil.NewClient(sshHost, info.KeyPath)
+	client := sshutil.NewClient(sshHost, info.KeyPath, info.VMDomain)
 
 	const maxReconnectAttempts = 5
 	const initialBackoff = 1 * time.Second

--- a/internal/handlers/copy.go
+++ b/internal/handlers/copy.go
@@ -86,7 +86,7 @@ func HandleCopy(ctx context.Context, a *app.App, r CopyReq) (presenters.CopyView
 	}
 
 	// Use native SFTP client
-	client := sshutil.NewClient(sshHost, info.KeyPath)
+	client := sshutil.NewClient(sshHost, info.KeyPath, info.VMDomain)
 	if isUpload {
 		err = client.Upload(ctx, expandTilde(localPath), remotePath, r.Recursive)
 	} else {

--- a/internal/handlers/execute.go
+++ b/internal/handlers/execute.go
@@ -38,13 +38,13 @@ func HandleExecute(ctx context.Context, a *app.App, r ExecuteReq) (presenters.Ex
 		return v, fmt.Errorf("failed to get VM information: %w", err)
 	}
 
-	// Use VM ID as host for SSH-over-TLS (will be formatted as {vm-id}.vm.vers.sh)
+	// Use VM ID as host for SSH-over-TLS (will be formatted as {vm-id}.{vmDomain})
 	sshHost := info.Host
 
 	cmdStr := strings.Join(r.Command, " ")
 
 	// Use native SSH client
-	client := sshutil.NewClient(sshHost, info.KeyPath)
+	client := sshutil.NewClient(sshHost, info.KeyPath, info.VMDomain)
 	err = client.Execute(ctx, cmdStr, a.IO.Out, a.IO.Err)
 	if err != nil {
 		// Check for SSH exit error to get exit code

--- a/internal/mcp/tools_execute.go
+++ b/internal/mcp/tools_execute.go
@@ -63,7 +63,7 @@ func registerExecuteTool(server *mcp.Server, application *app.App, opts Options)
 		errw := &sessionWriter{session: req.Session, level: "error"}
 
 		// Use native SSH client
-		client := sshutil.NewClient(sshHost, info.KeyPath)
+		client := sshutil.NewClient(sshHost, info.KeyPath, info.VMDomain)
 		runErr := client.Execute(runCtx, joinCmd(in.Command), outw, errw)
 		duration := time.Since(start)
 		target := ident

--- a/internal/services/vm/connect.go
+++ b/internal/services/vm/connect.go
@@ -11,10 +11,11 @@ import (
 
 // Info contains details needed to establish an SSH connection to a VM.
 type Info struct {
-	VM      *vers.Vm
-	Host    string // preferred host (node IP or fallback base hostname)
-	KeyPath string // local path to SSH private key
-	BaseURL *url.URL
+	VM       *vers.Vm
+	Host     string // preferred host (node IP or fallback base hostname)
+	KeyPath  string // local path to SSH private key
+	BaseURL  *url.URL
+	VMDomain string // VM domain suffix (e.g. "vm.vers.sh", "vm.staging.vers.sh")
 }
 
 // GetConnectInfo resolves the VM and returns connection information, including Node IP and SSH key.
@@ -33,8 +34,9 @@ func GetConnectInfo(ctx context.Context, client *vers.Client, identifier string)
 	}
 	out.BaseURL = versURL
 
-	// For SSH-over-TLS, use VM ID as host (will be formatted as {vm-id}.vm.vers.sh)
+	// For SSH-over-TLS, use VM ID as host (will be formatted as {vm-id}.{vmDomain})
 	out.Host = vm.VmID
+	out.VMDomain = auth.GetVMDomain()
 
 	keyPath, err := auth.GetOrCreateSSHKey(vm.VmID, client, ctx)
 	if err != nil {

--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -15,23 +15,33 @@ import (
 	"golang.org/x/term"
 )
 
+// DefaultVMDomain is the production VM domain suffix.
+const DefaultVMDomain = "vm.vers.sh"
+
 // Client provides native SSH connectivity over TLS.
 type Client struct {
-	host    string // VM ID (becomes {vm-id}.vm.vers.sh)
-	keyPath string // Path to SSH private key
+	host     string // VM ID (becomes {vm-id}.{vmDomain})
+	keyPath  string // Path to SSH private key
+	vmDomain string // VM domain suffix (e.g. "vm.vers.sh", "vm.staging.vers.sh")
 }
 
 // NewClient creates a new SSH client for the given VM.
-func NewClient(host, keyPath string) *Client {
+// Optional vmDomain overrides the default "vm.vers.sh" suffix.
+func NewClient(host, keyPath string, vmDomain ...string) *Client {
+	domain := DefaultVMDomain
+	if len(vmDomain) > 0 && vmDomain[0] != "" {
+		domain = vmDomain[0]
+	}
 	return &Client{
-		host:    host,
-		keyPath: keyPath,
+		host:     host,
+		keyPath:  keyPath,
+		vmDomain: domain,
 	}
 }
 
 // hostname returns the full hostname for TLS/SSH connection.
 func (c *Client) hostname() string {
-	return fmt.Sprintf("%s.vm.vers.sh", c.host)
+	return fmt.Sprintf("%s.%s", c.host, c.vmDomain)
 }
 
 // Host returns the host identifier (VM ID).

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -2,7 +2,7 @@
 //
 // This package implements SSH-over-TLS tunneling where SSH connections
 // are established through a TLS connection on port 443. VMs are accessed
-// via DNS hostnames in the format {vm-id}.vm.vers.sh.
+// via DNS hostnames in the format {vm-id}.{vmDomain} (e.g. {vm-id}.vm.vers.sh).
 package ssh
 
 import "strconv"

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -15,12 +15,31 @@ func TestNewClient(t *testing.T) {
 	if client.keyPath != "/path/to/key" {
 		t.Errorf("expected keyPath '/path/to/key', got %q", client.keyPath)
 	}
+	if client.vmDomain != DefaultVMDomain {
+		t.Errorf("expected vmDomain %q, got %q", DefaultVMDomain, client.vmDomain)
+	}
+}
+
+func TestNewClient_CustomDomain(t *testing.T) {
+	client := NewClient("test-vm-id", "/path/to/key", "vm.staging.vers.sh")
+	if client.vmDomain != "vm.staging.vers.sh" {
+		t.Errorf("expected vmDomain 'vm.staging.vers.sh', got %q", client.vmDomain)
+	}
 }
 
 func TestClient_Hostname(t *testing.T) {
 	client := NewClient("abc123", "/key")
 	hostname := client.hostname()
 	expected := "abc123.vm.vers.sh"
+	if hostname != expected {
+		t.Errorf("expected hostname %q, got %q", expected, hostname)
+	}
+}
+
+func TestClient_Hostname_Staging(t *testing.T) {
+	client := NewClient("abc123", "/key", "vm.staging.vers.sh")
+	hostname := client.hostname()
+	expected := "abc123.vm.staging.vers.sh"
 	if hostname != expected {
 		t.Errorf("expected hostname %q, got %q", expected, hostname)
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -165,7 +165,7 @@ func doConnectCmd(m Model, vmID string) tea.Cmd {
 		// Use native SSH client via Bubble Tea Exec
 		// We wrap the SSH interactive session in an exec.Cmd-like interface
 		return tea.Exec(&sshExecCmd{
-			client: sshutil.NewClient(sshHost, info.KeyPath),
+			client: sshutil.NewClient(sshHost, info.KeyPath, info.VMDomain),
 		}, func(err error) tea.Msg {
 			if err != nil {
 				return actionCompletedMsg{text: "SSH failed", err: err}

--- a/test/single-action/integration_connect_test.go
+++ b/test/single-action/integration_connect_test.go
@@ -62,7 +62,8 @@ func TestConnect_SSHOverTLS(t *testing.T) {
 
 	// Test SSH connection using SSH-over-TLS with retry logic
 	// Based on our debugging, first connections may fail if networking isn't fully ready
-	vmHostname := fmt.Sprintf("%s.vm.vers.sh", vmID)
+	vmDomain := auth.GetVMDomain()
+	vmHostname := fmt.Sprintf("%s.%s", vmID, vmDomain)
 	proxyCommand := fmt.Sprintf("openssl s_client -connect %s:443 -servername %s -quiet", vmHostname, vmHostname)
 
 	sshArgs := []string{


### PR DESCRIPTION
The SSH domain was hardcoded to vm.vers.sh, making it impossible to SSH into staging VMs at *.vm.staging.vers.sh.

Now derives the VM domain from VERS_URL by replacing the 'api.' prefix with 'vm.' (e.g. api.staging.vers.sh -> vm.staging.vers.sh).

Backward compatible: defaults to vm.vers.sh when no VERS_URL is set.