### PR TITLE
feat: add -t/--timeout flag to execute and copy commands

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"context"
+	"time"
 
 	"github.com/hdresearch/vers-cli/internal/handlers"
 	pres "github.com/hdresearch/vers-cli/internal/presenters"
 	"github.com/spf13/cobra"
 )
+
+var copyTimeout int
 
 // copyCmd represents the copy command
 var copyCmd = &cobra.Command{
@@ -21,7 +24,12 @@ Examples:
   vers copy -r ./local-dir/ /remote/path/  (recursive directory copy)`,
 	Args: cobra.RangeArgs(2, 3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		apiCtx, cancel := context.WithTimeout(context.Background(), application.Timeouts.APIMedium)
+		// Use custom timeout if specified, otherwise use default APIMedium
+		timeout := application.Timeouts.APIMedium
+		if copyTimeout > 0 {
+			timeout = time.Duration(copyTimeout) * time.Second
+		}
+		apiCtx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		recursive, _ := cmd.Flags().GetBool("recursive")
 		var target, source, destination string
@@ -42,4 +50,5 @@ Examples:
 func init() {
 	rootCmd.AddCommand(copyCmd)
 	copyCmd.Flags().BoolP("recursive", "r", false, "Recursively copy directories")
+	copyCmd.Flags().IntVarP(&copyTimeout, "timeout", "t", 0, "Timeout in seconds (default: 30s, use 0 for no limit)")
 }

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"context"
+	"time"
 
 	"github.com/hdresearch/vers-cli/internal/handlers"
 	pres "github.com/hdresearch/vers-cli/internal/presenters"
 	"github.com/spf13/cobra"
 )
+
+var executeTimeout int
 
 // executeCmd represents the execute command
 var executeCmd = &cobra.Command{
@@ -16,7 +19,12 @@ var executeCmd = &cobra.Command{
 If no VM is specified, the current HEAD VM is used.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		apiCtx, cancel := context.WithTimeout(context.Background(), application.Timeouts.APIMedium)
+		// Use custom timeout if specified, otherwise use default APIMedium
+		timeout := application.Timeouts.APIMedium
+		if executeTimeout > 0 {
+			timeout = time.Duration(executeTimeout) * time.Second
+		}
+		apiCtx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
 		// Determine if the first arg is a VM target or part of the command.
@@ -48,4 +56,5 @@ If no VM is specified, the current HEAD VM is used.`,
 func init() {
 	rootCmd.AddCommand(executeCmd)
 	executeCmd.Flags().String("host", "", "Specify the host IP to connect to (overrides default)")
+	executeCmd.Flags().IntVarP(&executeTimeout, "timeout", "t", 0, "Timeout in seconds (default: 30s, use 0 for no limit)")
 }


### PR DESCRIPTION
## Summary

Add configurable timeout flag to both `execute` and `copy` commands.

## Motivation

This is needed for long-running operations like Symphony agent runs where the default 30s timeout is insufficient. When running agents inside VMs, operations can take minutes rather than seconds.

## Usage

```bash
# Execute with 2 minute timeout
vers execute vm-id -t 120 -- some-long-command

# Copy with 1 minute timeout  
vers copy vm-id -t 60 ./local /remote/
```

## Changes

- Add `-t/--timeout` flag to `execute` command
- Add `-t/--timeout` flag to `copy` command
- Default behavior unchanged (uses APIMedium timeout when flag not specified)