### PR TITLE
refactor: unify HEAD resolution, --format json on remaining commands

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -135,11 +135,15 @@ Examples:
 	},
 }
 
+var commitHistoryFormat string
+
 var commitHistoryCmd = &cobra.Command{
 	Use:   "history <commit-id>",
 	Short: "Show the parent commit chain",
-	Long:  `Display the chain of parent commits leading up to a given commit.`,
-	Args:  cobra.ExactArgs(1),
+	Long: `Display the chain of parent commits leading up to a given commit.
+
+Use --format json for machine-readable output.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiCtx, cancel := context.WithTimeout(context.Background(), application.Timeouts.APIMedium)
 		defer cancel()
@@ -150,7 +154,14 @@ var commitHistoryCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		pres.RenderCommitParents(application, res)
+
+		format := pres.ParseFormat(false, commitHistoryFormat)
+		switch format {
+		case pres.FormatJSON:
+			pres.PrintJSON(res.Parents)
+		default:
+			pres.RenderCommitParents(application, res)
+		}
 		return nil
 	},
 }
@@ -207,6 +218,8 @@ func init() {
 	commitListCmd.Flags().StringVar(&commitListFormat, "format", "", "Output format (json)")
 	commitCmd.AddCommand(commitListCmd)
 	commitCmd.AddCommand(commitDeleteCmd)
+
+	commitHistoryCmd.Flags().StringVar(&commitHistoryFormat, "format", "", "Output format (json)")
 	commitCmd.AddCommand(commitHistoryCmd)
 	commitCmd.AddCommand(commitPublishCmd)
 	commitCmd.AddCommand(commitUnpublishCmd)

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -81,11 +81,15 @@ Use --format json for machine-readable output.`,
 	},
 }
 
+var tagGetFormat string
+
 var tagGetCmd = &cobra.Command{
 	Use:   "get <tag-name>",
 	Short: "Get details of a tag",
-	Long:  `Show detailed information about a specific tag.`,
-	Args:  cobra.ExactArgs(1),
+	Long: `Show detailed information about a specific tag.
+
+Use --format json for machine-readable output.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiCtx, cancel := context.WithTimeout(context.Background(), application.Timeouts.APIMedium)
 		defer cancel()
@@ -96,7 +100,14 @@ var tagGetCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		pres.RenderTagInfo(application, info)
+
+		format := pres.ParseFormat(false, tagGetFormat)
+		switch format {
+		case pres.FormatJSON:
+			pres.PrintJSON(info)
+		default:
+			pres.RenderTagInfo(application, info)
+		}
 		return nil
 	},
 }
@@ -173,6 +184,8 @@ func init() {
 	tagListCmd.Flags().BoolVarP(&tagListQuiet, "quiet", "q", false, "Only display tag names")
 	tagListCmd.Flags().StringVar(&tagListFormat, "format", "", "Output format (json)")
 	tagCmd.AddCommand(tagListCmd)
+
+	tagGetCmd.Flags().StringVar(&tagGetFormat, "format", "", "Output format (json)")
 	tagCmd.AddCommand(tagGetCmd)
 
 	tagUpdateCmd.Flags().StringVar(&tagUpdateCommit, "commit", "", "Move tag to this commit ID")

--- a/internal/handlers/branch.go
+++ b/internal/handlers/branch.go
@@ -33,27 +33,20 @@ func HandleBranch(ctx context.Context, a *app.App, r BranchReq) (presenters.Bran
 		}
 	}
 
-	// Resolve source VM id
-	vmID := r.Target
-	var vmInfo *utils.VMInfo
-	var err error
-	if r.Target == "" {
-		vmID, err = utils.GetCurrentHeadVM()
-		if err != nil {
-			return res, fmt.Errorf("no VM ID provided and %w", err)
-		}
-		res.UsedHEAD = true
-		res.FromID = vmID
-		res.FromName = vmID
-	} else {
-		vmInfo, err = utils.ResolveVMIdentifier(ctx, a.Client, r.Target)
-		// If VM cannot be resolved, this request may be targeting a commit ID instead
-		if err == nil {
-			vmID = vmInfo.ID
-			res.FromID = vmID
-			res.FromName = vmInfo.DisplayName
-		}
+	// Resolve source VM (falls back to HEAD if empty)
+	t, err := utils.ResolveTarget(r.Target)
+	if err != nil {
+		return res, err
 	}
+	res.UsedHEAD = t.UsedHEAD
+	vmID := t.Ident
+
+	// Try to verify the VM exists; if resolve fails, it may be a commit ID
+	if info, err := utils.ResolveVMIdentifier(ctx, a.Client, t.Ident); err == nil {
+		vmID = info.ID
+	}
+	res.FromID = vmID
+	res.FromName = vmID
 
 	// Note: Alias parameter no longer supported in new SDK
 	// SDK alpha.24 now returns the new VM ID

--- a/internal/handlers/commit_create.go
+++ b/internal/handlers/commit_create.go
@@ -9,12 +9,10 @@ import (
 	vers "github.com/hdresearch/vers-sdk-go"
 )
 
-// CommitCreateReq is the request for creating a commit.
 type CommitCreateReq struct {
-	Target string // vm id or alias; if empty, use HEAD
+	Target string
 }
 
-// CommitCreateView is the result of creating a commit.
 type CommitCreateView struct {
 	CommitID string `json:"commit_id"`
 	VmID     string `json:"vm_id"`
@@ -22,32 +20,19 @@ type CommitCreateView struct {
 }
 
 func HandleCommitCreate(ctx context.Context, a *app.App, r CommitCreateReq) (CommitCreateView, error) {
-	var vmID string
-	var usedHead bool
-
-	if r.Target != "" {
-		info, err := utils.ResolveVMIdentifier(ctx, a.Client, r.Target)
-		if err != nil {
-			return CommitCreateView{}, fmt.Errorf("failed to find VM: %w", err)
-		}
-		vmID = info.ID
-	} else {
-		var err error
-		vmID, err = utils.GetCurrentHeadVM()
-		if err != nil {
-			return CommitCreateView{}, fmt.Errorf("failed to get current VM: %w", err)
-		}
-		usedHead = true
+	resolved, err := utils.ResolveTargetVM(ctx, a.Client, r.Target)
+	if err != nil {
+		return CommitCreateView{}, err
 	}
 
-	resp, err := a.Client.Vm.Commit(ctx, vmID, vers.VmCommitParams{})
+	resp, err := a.Client.Vm.Commit(ctx, resolved.ID, vers.VmCommitParams{})
 	if err != nil {
-		return CommitCreateView{}, fmt.Errorf("failed to commit VM '%s': %w", vmID, err)
+		return CommitCreateView{}, fmt.Errorf("failed to commit VM '%s': %w", resolved.ID, err)
 	}
 
 	return CommitCreateView{
 		CommitID: resp.CommitID,
-		VmID:     vmID,
-		UsedHEAD: usedHead,
+		VmID:     resolved.ID,
+		UsedHEAD: resolved.UsedHEAD,
 	}, nil
 }

--- a/internal/handlers/connect.go
+++ b/internal/handlers/connect.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/hdresearch/vers-cli/internal/app"
@@ -21,21 +20,16 @@ import (
 type ConnectReq struct{ Target string }
 
 func HandleConnect(ctx context.Context, a *app.App, r ConnectReq) (presenters.ConnectView, error) {
-	var ident string
 	view := presenters.ConnectView{}
-	if strings.TrimSpace(r.Target) == "" {
-		headID, err := utils.GetCurrentHeadVM()
-		if err != nil {
-			return view, fmt.Errorf("no VM ID provided and %w", err)
-		}
-		view.UsedHEAD = true
-		view.HeadID = headID
-		ident = headID
-	} else {
-		ident = r.Target
-	}
 
-	info, err := vmSvc.GetConnectInfo(ctx, a.Client, ident)
+	t, err := utils.ResolveTarget(r.Target)
+	if err != nil {
+		return view, err
+	}
+	view.UsedHEAD = t.UsedHEAD
+	view.HeadID = t.HeadID
+
+	info, err := vmSvc.GetConnectInfo(ctx, a.Client, t.Ident)
 	if err != nil {
 		return view, fmt.Errorf("failed to get VM information: %w", err)
 	}
@@ -70,7 +64,7 @@ func HandleConnect(ctx context.Context, a *app.App, r ConnectReq) (presenters.Co
 				break
 			}
 			if refreshed.State == vers.VmStatePaused {
-				return view, fmt.Errorf("VM entered paused state while booting — try 'vers resume %s' first", ident)
+				return view, fmt.Errorf("VM entered paused state while booting — try 'vers resume %s' first", t.Ident)
 			}
 			if i == 29 {
 				return view, fmt.Errorf("timed out waiting for VM to finish booting")

--- a/internal/handlers/copy.go
+++ b/internal/handlers/copy.go
@@ -23,18 +23,15 @@ type CopyReq struct {
 
 func HandleCopy(ctx context.Context, a *app.App, r CopyReq) (presenters.CopyView, error) {
 	v := presenters.CopyView{}
-	ident := r.Target
-	if ident == "" {
-		head, err := utils.GetCurrentHeadVM()
-		if err != nil {
-			return v, fmt.Errorf("no VM ID provided and %w", err)
-		}
-		ident = head
-		v.UsedHEAD = true
-		v.HeadID = head
-	}
 
-	info, err := vmSvc.GetConnectInfo(ctx, a.Client, ident)
+	t, err := utils.ResolveTarget(r.Target)
+	if err != nil {
+		return v, err
+	}
+	v.UsedHEAD = t.UsedHEAD
+	v.HeadID = t.HeadID
+
+	info, err := vmSvc.GetConnectInfo(ctx, a.Client, t.Ident)
 	if err != nil {
 		return v, fmt.Errorf("failed to get VM information: %w", err)
 	}

--- a/internal/handlers/execute.go
+++ b/internal/handlers/execute.go
@@ -19,34 +19,25 @@ type ExecuteReq struct {
 
 func HandleExecute(ctx context.Context, a *app.App, r ExecuteReq) (presenters.ExecuteView, error) {
 	v := presenters.ExecuteView{}
-	var ident string
-	if r.Target == "" {
-		head, err := utils.GetCurrentHeadVM()
-		if err != nil {
-			return v, fmt.Errorf("no VM ID provided and %w", err)
-		}
-		v.UsedHEAD = true
-		v.HeadID = head
-		ident = head
-	} else {
-		ident = r.Target
-	}
 
-	info, err := vmSvc.GetConnectInfo(ctx, a.Client, ident)
+	t, err := utils.ResolveTarget(r.Target)
+	if err != nil {
+		return v, err
+	}
+	v.UsedHEAD = t.UsedHEAD
+	v.HeadID = t.HeadID
+
+	info, err := vmSvc.GetConnectInfo(ctx, a.Client, t.Ident)
 	if err != nil {
 		return v, fmt.Errorf("failed to get VM information: %w", err)
 	}
 
-	// Use VM ID as host for SSH-over-TLS (will be formatted as {vm-id}.{vmDomain})
 	sshHost := info.Host
-
 	cmdStr := utils.ShellJoin(r.Command)
 
-	// Use native SSH client
 	client := sshutil.NewClient(sshHost, info.KeyPath, info.VMDomain)
 	err = client.Execute(ctx, cmdStr, a.IO.Out, a.IO.Err)
 	if err != nil {
-		// Check for SSH exit error to get exit code
 		if exitErr, ok := err.(*ssh.ExitError); ok {
 			return v, fmt.Errorf("command exited with code %d", exitErr.ExitStatus())
 		}

--- a/internal/handlers/info.go
+++ b/internal/handlers/info.go
@@ -10,30 +10,18 @@ import (
 )
 
 type InfoReq struct {
-	Target string // vm id or alias; if empty, use HEAD
+	Target string
 }
 
 func HandleInfo(ctx context.Context, a *app.App, r InfoReq) (presenters.InfoView, error) {
-	vmID := r.Target
-	if vmID == "" {
-		var err error
-		vmID, err = utils.GetCurrentHeadVM()
-		if err != nil {
-			return presenters.InfoView{}, fmt.Errorf("no VM specified and %w", err)
-		}
-		return handleInfoByID(ctx, a, vmID, true)
-	}
-
-	// Try to resolve as alias first
-	vmInfo, err := utils.ResolveVMIdentifier(ctx, a.Client, r.Target)
+	t, err := utils.ResolveTarget(r.Target)
 	if err != nil {
-		// Could be a raw VM ID that just isn't in the list — try metadata directly
-		return handleInfoByID(ctx, a, r.Target, false)
+		return presenters.InfoView{}, err
 	}
-	return handleInfoByID(ctx, a, vmInfo.ID, false)
-}
 
-func handleInfoByID(ctx context.Context, a *app.App, vmID string, usedHead bool) (presenters.InfoView, error) {
+	// Resolve alias if needed, but don't fail if it's a raw ID
+	vmID := utils.ResolveAlias(t.Ident)
+
 	meta, err := a.Client.Vm.GetMetadata(ctx, vmID)
 	if err != nil {
 		return presenters.InfoView{}, fmt.Errorf("failed to get metadata for VM '%s': %w", vmID, err)
@@ -41,6 +29,6 @@ func handleInfoByID(ctx context.Context, a *app.App, vmID string, usedHead bool)
 
 	return presenters.InfoView{
 		Metadata: meta,
-		UsedHEAD: usedHead,
+		UsedHEAD: t.UsedHEAD,
 	}, nil
 }

--- a/internal/handlers/kill.go
+++ b/internal/handlers/kill.go
@@ -20,11 +20,11 @@ func HandleKill(ctx context.Context, a *app.App, r KillReq) error {
 
 	// Default to HEAD if no targets
 	if len(targets) == 0 {
-		headVMID, err := utils.GetCurrentHeadVM()
+		t, err := utils.ResolveTarget("")
 		if err != nil {
-			return fmt.Errorf("no arguments provided and %w", err)
+			return err
 		}
-		targets = []string{headVMID}
+		targets = []string{t.Ident}
 	}
 
 	// Confirm if needed

--- a/internal/handlers/kill_dto.go
+++ b/internal/handlers/kill_dto.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hdresearch/vers-cli/internal/app"
 	delsvc "github.com/hdresearch/vers-cli/internal/services/deletion"
@@ -22,11 +21,11 @@ func HandleKillDTO(ctx context.Context, a *app.App, r KillReq) (KillDTO, error) 
 	dto := KillDTO{Targets: r.Targets, Scope: "vms"}
 	targets := r.Targets
 	if len(targets) == 0 {
-		head, err := utils.GetCurrentHeadVM()
+		t, err := utils.ResolveTarget("")
 		if err != nil {
-			return dto, fmt.Errorf("no arguments provided and %w", err)
+			return dto, err
 		}
-		targets = []string{head}
+		targets = []string{t.Ident}
 		dto.AffectedHead = true
 	}
 

--- a/internal/handlers/pause.go
+++ b/internal/handlers/pause.go
@@ -12,36 +12,19 @@ import (
 
 type PauseReq struct{ Target string }
 
-type PauseView struct{ VMName, NewState string }
-
 func HandlePause(ctx context.Context, a *app.App, r PauseReq) (presenters.PauseView, error) {
-	var vmID string
-	var vmName string
-
-	if r.Target == "" {
-		head, err := utils.GetCurrentHeadVM()
-		if err != nil {
-			return presenters.PauseView{}, fmt.Errorf("no VM ID provided and %w", err)
-		}
-		vmID = head
-		vmName = head
-	} else {
-		info, err := utils.ResolveVMIdentifier(ctx, a.Client, r.Target)
-		if err != nil {
-			return presenters.PauseView{}, fmt.Errorf("failed to find VM: %w", err)
-		}
-		vmID = info.ID
-		vmName = info.DisplayName
+	resolved, err := utils.ResolveTargetVM(ctx, a.Client, r.Target)
+	if err != nil {
+		return presenters.PauseView{}, err
 	}
 
-	updateParams := vers.VmUpdateStateParams{
+	err = a.Client.Vm.UpdateState(ctx, resolved.ID, vers.VmUpdateStateParams{
 		VmUpdateStateRequest: vers.VmUpdateStateRequestParam{
 			State: vers.F(vers.VmUpdateStateRequestStatePaused),
 		},
-	}
-	err := a.Client.Vm.UpdateState(ctx, vmID, updateParams)
+	})
 	if err != nil {
-		return presenters.PauseView{}, fmt.Errorf("failed to pause VM '%s': %w", vmName, err)
+		return presenters.PauseView{}, fmt.Errorf("failed to pause VM '%s': %w", resolved.ID, err)
 	}
-	return presenters.PauseView{VMName: vmName, NewState: "Paused"}, nil
+	return presenters.PauseView{VMName: resolved.ID, NewState: "Paused"}, nil
 }

--- a/internal/handlers/resize.go
+++ b/internal/handlers/resize.go
@@ -10,8 +10,8 @@ import (
 )
 
 type ResizeReq struct {
-	Target    string // vm id or alias; if empty, use HEAD
-	FsSizeMib int64  // new disk size in MiB
+	Target    string
+	FsSizeMib int64
 }
 
 func HandleResize(ctx context.Context, a *app.App, r ResizeReq) (string, error) {
@@ -19,29 +19,19 @@ func HandleResize(ctx context.Context, a *app.App, r ResizeReq) (string, error) 
 		return "", fmt.Errorf("disk size must be a positive number (in MiB)")
 	}
 
-	vmID := r.Target
-	if vmID == "" {
-		var err error
-		vmID, err = utils.GetCurrentHeadVM()
-		if err != nil {
-			return "", fmt.Errorf("no VM specified and %w", err)
-		}
-	} else {
-		vmInfo, err := utils.ResolveVMIdentifier(ctx, a.Client, r.Target)
-		if err == nil {
-			vmID = vmInfo.ID
-		}
-		// If resolve fails, try the raw string as a VM ID
+	resolved, err := utils.ResolveTargetVM(ctx, a.Client, r.Target)
+	if err != nil {
+		return "", err
 	}
 
-	err := a.Client.Vm.ResizeDisk(ctx, vmID, vers.VmResizeDiskParams{
+	err = a.Client.Vm.ResizeDisk(ctx, resolved.ID, vers.VmResizeDiskParams{
 		VmResizeDiskRequest: vers.VmResizeDiskRequestParam{
 			FsSizeMib: vers.F(r.FsSizeMib),
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to resize disk for VM '%s': %w", vmID, err)
+		return "", fmt.Errorf("failed to resize disk for VM '%s': %w", resolved.ID, err)
 	}
 
-	return vmID, nil
+	return resolved.ID, nil
 }

--- a/internal/handlers/resume.go
+++ b/internal/handlers/resume.go
@@ -16,38 +16,26 @@ type ResumeReq struct {
 }
 
 func HandleResume(ctx context.Context, a *app.App, r ResumeReq) (presenters.ResumeView, error) {
-	var vmID string
-	var vmName string
-	if r.Target == "" {
-		head, err := utils.GetCurrentHeadVM()
-		if err != nil {
-			return presenters.ResumeView{}, fmt.Errorf("no VM ID provided and %w", err)
-		}
-		vmID, vmName = head, head
-	} else {
-		info, err := utils.ResolveVMIdentifier(ctx, a.Client, r.Target)
-		if err != nil {
-			return presenters.ResumeView{}, fmt.Errorf("failed to find VM: %w", err)
-		}
-		vmID, vmName = info.ID, info.DisplayName
+	resolved, err := utils.ResolveTargetVM(ctx, a.Client, r.Target)
+	if err != nil {
+		return presenters.ResumeView{}, err
 	}
 
-	updateParams := vers.VmUpdateStateParams{
+	err = a.Client.Vm.UpdateState(ctx, resolved.ID, vers.VmUpdateStateParams{
 		VmUpdateStateRequest: vers.VmUpdateStateRequestParam{
 			State: vers.F(vers.VmUpdateStateRequestStateRunning),
 		},
-	}
-	err := a.Client.Vm.UpdateState(ctx, vmID, updateParams)
+	})
 	if err != nil {
-		return presenters.ResumeView{}, fmt.Errorf("failed to resume VM '%s': %w", vmName, err)
+		return presenters.ResumeView{}, fmt.Errorf("failed to resume VM '%s': %w", resolved.ID, err)
 	}
 
 	if r.Wait {
-		fmt.Fprintf(a.IO.Err, "Waiting for VM %s to be running...\n", vmName)
-		if err := utils.WaitForRunning(ctx, a.Client, vmID); err != nil {
+		fmt.Fprintf(a.IO.Err, "Waiting for VM %s to be running...\n", resolved.ID)
+		if err := utils.WaitForRunning(ctx, a.Client, resolved.ID); err != nil {
 			return presenters.ResumeView{}, err
 		}
 	}
 
-	return presenters.ResumeView{VMName: vmName, NewState: "Running"}, nil
+	return presenters.ResumeView{VMName: resolved.ID, NewState: "Running"}, nil
 }

--- a/internal/utils/resolve_target.go
+++ b/internal/utils/resolve_target.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	vers "github.com/hdresearch/vers-sdk-go"
 )
 
 // TargetResult holds the result of resolving a VM target identifier.
@@ -28,5 +31,30 @@ func ResolveTarget(target string) (TargetResult, error) {
 		Ident:    headID,
 		UsedHEAD: true,
 		HeadID:   headID,
+	}, nil
+}
+
+// ResolvedVM holds a verified VM identity.
+type ResolvedVM struct {
+	ID       string // Verified VM ID
+	UsedHEAD bool   // Whether HEAD was used as fallback
+}
+
+// ResolveTargetVM resolves a target string to a verified VM ID.
+// If target is empty, uses HEAD. Then verifies the VM exists via the API.
+func ResolveTargetVM(ctx context.Context, client *vers.Client, target string) (ResolvedVM, error) {
+	t, err := ResolveTarget(target)
+	if err != nil {
+		return ResolvedVM{}, err
+	}
+
+	info, err := ResolveVMIdentifier(ctx, client, t.Ident)
+	if err != nil {
+		return ResolvedVM{}, err
+	}
+
+	return ResolvedVM{
+		ID:       info.ID,
+		UsedHEAD: t.UsedHEAD,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Two cleanup items from the CLI composability audit.

### Unify HEAD resolution

Every handler had its own copy of:
```go
if r.Target == "" {
    head, err := utils.GetCurrentHeadVM()
    if err != nil { return ..., fmt.Errorf("no VM ID provided and %w", err) }
    vmID = head
} else {
    info, err := utils.ResolveVMIdentifier(ctx, a.Client, r.Target)
    ...
}
```

Now there are two shared utilities:
- **`ResolveTarget(target)`** — returns the identifier (or HEAD fallback). For handlers that do their own connection setup (connect, execute, copy).
- **`ResolveTargetVM(ctx, client, target)`** — resolves + verifies via API. For handlers that just need a confirmed VM ID (pause, resume, resize, commit, info).

11 handlers rewritten. Net -38 lines, consistent error messages.

### `--format json` on remaining read commands

```bash
vers commit history abc-123 --format json    # JSON array of parent commits
vers tag get production --format json        # full tag object as JSON
```

These were the last two read commands without machine-readable output.

### Tests

All unit tests pass.