### PR TITLE
feat: add -i/--interactive stdin support to vers exec

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -2,17 +2,21 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"time"
 
 	"github.com/hdresearch/vers-cli/internal/handlers"
 	pres "github.com/hdresearch/vers-cli/internal/presenters"
+	"github.com/hdresearch/vers-cli/internal/utils"
 	"github.com/spf13/cobra"
 )
 
 var executeTimeout int
 var executeSSH bool
 var executeWorkDir string
+var executeStdin bool
 
 // executeCmd represents the execute command
 var executeCmd = &cobra.Command{
@@ -25,6 +29,11 @@ The command runs through the in-VM agent, which means it automatically
 inherits environment variables configured for your account.
 
 If no VM is specified, the current HEAD VM is used.
+
+Use -i to pass stdin from the local terminal to the remote command.
+This is useful for piping data into commands, e.g.:
+
+  echo '{"jsonrpc":"2.0","method":"ping","id":1}' | vers exec -i <vm> my-server
 
 Use --ssh to bypass the API and connect directly via SSH (legacy behavior).`,
 	Args: cobra.MinimumNArgs(1),
@@ -39,24 +48,36 @@ Use --ssh to bypass the API and connect directly via SSH (legacy behavior).`,
 
 		// Determine if the first arg is a VM target or part of the command.
 		// If there's only one arg, it's the command (use HEAD VM).
-		// If there are multiple args, try to resolve the first arg as a VM;
-		// if it resolves, treat it as the target, otherwise treat all args as the command.
+		// If there are multiple args, check if the first arg looks like a VM
+		// identifier (UUID or known alias). If so, treat it as the target;
+		// otherwise treat all args as the command and use HEAD.
 		var target string
 		var command []string
 
 		if len(args) == 1 {
-			// Only a command, use HEAD VM
 			target = ""
 			command = args
-		} else {
-			// First arg is the target VM, remaining args are the command
+		} else if utils.LooksLikeVMTarget(args[0]) {
 			target = args[0]
 			command = args[1:]
+		} else {
+			target = ""
+			command = args
 		}
 
 		var timeoutSec uint64
 		if executeTimeout > 0 {
 			timeoutSec = uint64(executeTimeout)
+		}
+
+		// Read stdin if -i flag is set
+		var stdinData string
+		if executeStdin {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("failed to read stdin: %w", err)
+			}
+			stdinData = string(data)
 		}
 
 		view, err := handlers.HandleExecute(apiCtx, application, handlers.ExecuteReq{
@@ -65,6 +86,7 @@ Use --ssh to bypass the API and connect directly via SSH (legacy behavior).`,
 			WorkingDir: executeWorkDir,
 			TimeoutSec: timeoutSec,
 			UseSSH:     executeSSH,
+			Stdin:      stdinData,
 		})
 		if err != nil {
 			return err
@@ -85,4 +107,5 @@ func init() {
 	executeCmd.Flags().IntVarP(&executeTimeout, "timeout", "t", 0, "Timeout in seconds (default: 30s, use 0 for no limit)")
 	executeCmd.Flags().BoolVar(&executeSSH, "ssh", false, "Use direct SSH instead of the VERS API")
 	executeCmd.Flags().StringVarP(&executeWorkDir, "workdir", "w", "", "Working directory for the command")
+	executeCmd.Flags().BoolVarP(&executeStdin, "interactive", "i", false, "Pass stdin to the remote command")
 }

--- a/cmd/execute_test.go
+++ b/cmd/execute_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TestExecuteCommandArgumentParsing tests the argument parsing logic for execute
+// TestExecuteCommandArgumentParsing tests the argument parsing logic for execute.
+// The logic uses LooksLikeVMTarget to decide if the first arg is a VM or a command:
+//   - UUID → treated as VM target
+//   - Known alias → treated as VM target
+//   - Anything else → treated as command, uses HEAD
 func TestExecuteCommandArgumentParsing(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -19,25 +23,46 @@ func TestExecuteCommandArgumentParsing(t *testing.T) {
 		errorMessage    string
 	}{
 		{
-			name:            "2+ args: first is target, rest is command",
-			args:            []string{"my-vm", "echo", "hello"},
+			name:            "UUID target + command args",
+			args:            []string{"3bfea344-6bf2-4655-be27-64be7b5eb332", "echo", "hello"},
 			expectError:     false,
-			expectedTarget:  "my-vm",
+			expectedTarget:  "3bfea344-6bf2-4655-be27-64be7b5eb332",
 			expectedCommand: []string{"echo", "hello"},
 		},
 		{
-			name:            "2 args: target and single command",
-			args:            []string{"my-vm", "ls"},
+			name:            "UUID target + single command",
+			args:            []string{"3bfea344-6bf2-4655-be27-64be7b5eb332", "ls"},
 			expectError:     false,
-			expectedTarget:  "my-vm",
+			expectedTarget:  "3bfea344-6bf2-4655-be27-64be7b5eb332",
 			expectedCommand: []string{"ls"},
 		},
 		{
-			name:            "1 arg: command only, uses HEAD",
+			name:            "command only (not a UUID), uses HEAD",
+			args:            []string{"echo", "hello"},
+			expectError:     false,
+			expectedTarget:  "",
+			expectedCommand: []string{"echo", "hello"},
+		},
+		{
+			name:            "single command, uses HEAD",
 			args:            []string{"echo hello"},
 			expectError:     false,
 			expectedTarget:  "",
 			expectedCommand: []string{"echo hello"},
+		},
+		{
+			name:            "command with path, not a UUID",
+			args:            []string{"jq", ".foo"},
+			expectError:     false,
+			expectedTarget:  "",
+			expectedCommand: []string{"jq", ".foo"},
+		},
+		{
+			name:            "python command, not a UUID",
+			args:            []string{"python3", "-c", "print('hi')"},
+			expectError:     false,
+			expectedTarget:  "",
+			expectedCommand: []string{"python3", "-c", "print('hi')"},
 		},
 		{
 			name:         "0 args: error",
@@ -59,14 +84,18 @@ func TestExecuteCommandArgumentParsing(t *testing.T) {
 					if len(args) == 1 {
 						capturedTarget = ""
 						capturedCommand = args
-					} else {
+					} else if utils.LooksLikeVMTarget(args[0]) {
 						capturedTarget = args[0]
 						capturedCommand = args[1:]
+					} else {
+						capturedTarget = ""
+						capturedCommand = args
 					}
 					return nil
 				},
 			}
 
+			cmd.Flags().SetInterspersed(false)
 			cmd.SetArgs(tt.args)
 			err := cmd.Execute()
 
@@ -139,9 +168,12 @@ func TestExecuteCommandWithHEAD(t *testing.T) {
 	if len(args) == 1 {
 		target = ""
 		command = args
-	} else {
+	} else if utils.LooksLikeVMTarget(args[0]) {
 		target = args[0]
 		command = args[1:]
+	} else {
+		target = ""
+		command = args
 	}
 
 	// When target is empty, HEAD should be used

--- a/internal/handlers/execute.go
+++ b/internal/handlers/execute.go
@@ -23,6 +23,7 @@ type ExecuteReq struct {
 	Env        map[string]string
 	TimeoutSec uint64
 	UseSSH     bool
+	Stdin      string
 }
 
 // streamResponse represents a single NDJSON line from the exec stream.
@@ -67,6 +68,7 @@ func handleExecuteAPI(ctx context.Context, a *app.App, r ExecuteReq, t utils.Tar
 		Command:    command,
 		Env:        r.Env,
 		WorkingDir: r.WorkingDir,
+		Stdin:      r.Stdin,
 		TimeoutSec: r.TimeoutSec,
 	})
 	if err != nil {
@@ -92,6 +94,11 @@ func handleExecuteSSH(ctx context.Context, a *app.App, r ExecuteReq, t utils.Tar
 
 	cmdStr := utils.ShellJoin(r.Command)
 	client := sshutil.NewClient(info.Host, info.KeyPath, info.VMDomain)
+
+	if r.Stdin != "" {
+		return handleExecuteSSHWithStdin(ctx, client, cmdStr, r.Stdin, a, v)
+	}
+
 	err = client.Execute(ctx, cmdStr, a.IO.Out, a.IO.Err)
 	if err != nil {
 		if exitErr, ok := err.(*ssh.ExitError); ok {
@@ -99,6 +106,39 @@ func handleExecuteSSH(ctx context.Context, a *app.App, r ExecuteReq, t utils.Tar
 			return v, nil
 		}
 		return v, fmt.Errorf("failed to execute command: %w", err)
+	}
+	return v, nil
+}
+
+// handleExecuteSSHWithStdin runs a command via SSH, piping stdin data to the remote process.
+func handleExecuteSSHWithStdin(ctx context.Context, client *sshutil.Client, cmd, stdinData string, a *app.App, v presenters.ExecuteView) (presenters.ExecuteView, error) {
+	sess, err := client.StartSession(ctx)
+	if err != nil {
+		return v, fmt.Errorf("failed to start SSH session: %w", err)
+	}
+	defer sess.Close()
+
+	// Copy stdout/stderr in background
+	go io.Copy(a.IO.Out, sess.Stdout())
+	go io.Copy(a.IO.Err, sess.Stderr())
+
+	if err := sess.Start(cmd); err != nil {
+		return v, fmt.Errorf("failed to start command: %w", err)
+	}
+
+	// Write stdin data and close to signal EOF
+	if _, err := io.WriteString(sess.Stdin(), stdinData); err != nil {
+		return v, fmt.Errorf("failed to write stdin: %w", err)
+	}
+	sess.Stdin().Close()
+
+	err = sess.Wait()
+	if err != nil {
+		if exitErr, ok := err.(*ssh.ExitError); ok {
+			v.ExitCode = exitErr.ExitStatus()
+			return v, nil
+		}
+		return v, fmt.Errorf("command failed: %w", err)
 	}
 	return v, nil
 }

--- a/internal/utils/vm_target.go
+++ b/internal/utils/vm_target.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"regexp"
+)
+
+// uuidRegex matches a standard UUID v4 format.
+var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// LooksLikeVMTarget returns true if the string looks like a VM identifier
+// (a UUID or a known alias), as opposed to a shell command.
+func LooksLikeVMTarget(s string) bool {
+	if uuidRegex.MatchString(s) {
+		return true
+	}
+
+	// Check if it's a known alias
+	resolved := ResolveAlias(s)
+	if resolved != s {
+		return true
+	}
+
+	return false
+}

--- a/internal/utils/vm_target_test.go
+++ b/internal/utils/vm_target_test.go
@@ -38,11 +38,17 @@ func TestLooksLikeVMTarget_UUID(t *testing.T) {
 }
 
 func TestLooksLikeVMTarget_Alias(t *testing.T) {
-	// Set up a temp home dir with aliases
-	origHome := os.Getenv("HOME")
+	// Set up a temp home dir with aliases.
+	// Must set both HOME (Unix) and USERPROFILE (Windows) since
+	// os.UserHomeDir() checks USERPROFILE on Windows.
 	tmpHome := t.TempDir()
+
+	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
 	os.Setenv("HOME", tmpHome)
+	os.Setenv("USERPROFILE", tmpHome)
 	defer os.Setenv("HOME", origHome)
+	defer os.Setenv("USERPROFILE", origUserProfile)
 
 	aliasDir := filepath.Join(tmpHome, ".vers")
 	os.MkdirAll(aliasDir, 0755)

--- a/internal/utils/vm_target_test.go
+++ b/internal/utils/vm_target_test.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLooksLikeVMTarget_UUID(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{"valid UUID", "3bfea344-6bf2-4655-be27-64be7b5eb332", true},
+		{"valid UUID uppercase", "3BFEA344-6BF2-4655-BE27-64BE7B5EB332", true},
+		{"valid UUID mixed case", "3bFeA344-6Bf2-4655-bE27-64bE7b5eB332", true},
+		{"zeroed UUID", "00000000-0000-0000-0000-000000000000", true},
+		{"not a UUID - command", "echo", false},
+		{"not a UUID - command with path", "/usr/bin/cat", false},
+		{"not a UUID - partial UUID", "3bfea344-6bf2", false},
+		{"not a UUID - jq", "jq", false},
+		{"not a UUID - python3", "python3", false},
+		{"not a UUID - ls", "ls", false},
+		{"not a UUID - bash", "bash", false},
+		{"not a UUID - empty", "", false},
+		{"not a UUID - UUID without dashes", "3bfea3446bf24655be2764be7b5eb332", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LooksLikeVMTarget(tt.input)
+			if got != tt.expect {
+				t.Errorf("LooksLikeVMTarget(%q) = %v, want %v", tt.input, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestLooksLikeVMTarget_Alias(t *testing.T) {
+	// Set up a temp home dir with aliases
+	origHome := os.Getenv("HOME")
+	tmpHome := t.TempDir()
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	aliasDir := filepath.Join(tmpHome, ".vers")
+	os.MkdirAll(aliasDir, 0755)
+	os.WriteFile(filepath.Join(aliasDir, "aliases.json"), []byte(`{"my-dev-vm":"3bfea344-6bf2-4655-be27-64be7b5eb332"}`), 0644)
+
+	tests := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{"known alias", "my-dev-vm", true},
+		{"unknown alias", "no-such-alias", false},
+		{"command not alias", "cat", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LooksLikeVMTarget(tt.input)
+			if got != tt.expect {
+				t.Errorf("LooksLikeVMTarget(%q) = %v, want %v", tt.input, got, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `-i`/`--interactive` flag to `vers exec` that pipes local stdin to the remote command via the orchestrator API's existing `stdin` field. Useful for piping data into commands running on VMs.

## Usage

```bash
# Pipe JSON through jq on the VM
cat data.json | vers exec -i jq '.foo'

# One-shot MCP request
echo '{"jsonrpc":"2.0","method":"ping","id":1}' | vers exec -i my-mcp-server

# Works with --ssh fallback too
cat input.txt | vers exec -i --ssh python3 process.py
```

## Changes

### `-i` flag (`cmd/execute.go`)
- When set, reads all of stdin before sending the exec request
- Passes the data into `ExecuteReq.Stdin`

### Handler stdin passthrough (`internal/handlers/execute.go`)
- **API path**: passes `Stdin` through to `ExecRequest.Stdin` (orchestrator already supports this field)
- **SSH path**: uses `StartSession()` to get stdin/stdout/stderr pipes, writes the data, closes stdin to signal EOF

### Arg parsing fix (`cmd/execute.go`, `internal/utils/vm_target.go`)
- **Bug**: previously, `vers exec jq '.foo'` would treat `jq` as a VM ID and fail with a UUID parse error
- **Fix**: uses `LooksLikeVMTarget()` to check if the first arg is a UUID or known alias before treating it as a VM target; otherwise treats all args as the command and uses HEAD

### Tests
- `internal/utils/vm_target_test.go` — 17 test cases for `LooksLikeVMTarget` (UUIDs, commands, aliases, edge cases)
- `cmd/execute_test.go` — updated arg parsing tests for the new logic

## Notes

This is **one-shot stdin** (reads all input, sends it, gets the response) — not a persistent bidirectional channel. For long-lived interactive sessions, `vers connect` or MCP-over-HTTP with tunneling is still the right approach.