### PR TITLE
fix(update): make "update available" nag actually print

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -179,17 +179,17 @@ interaction capabilities, and more.`,
 			cmd.CalledAs() == "help" ||
 			cmd.Name() == "upgrade"
 
-		if !skipUpdateCheck && update.ShouldCheckForUpdate() {
-			// Update the check time regardless of result
-			update.UpdateCheckTime()
-			// Check for updates in background
-			go func() {
-				DebugPrint("Checking for updates...\n")
-				hasUpdate, latestVersion, err := update.CheckForUpdates(Version, Repository, verbose)
-				if err == nil && hasUpdate {
-					fmt.Printf("💡 Update available: %s -> %s (run 'vers upgrade')\n\n", Version, latestVersion)
-				}
-			}()
+		if !skipUpdateCheck {
+			// Synchronous update check with a tight timeout. Uses a
+			// disk-cached "latest known release" so the nag prints
+			// instantly on subsequent runs without any network I/O,
+			// and only refreshes once per check interval.
+			//
+			// Done synchronously (not in a goroutine) because short
+			// commands like `vers ps` would exit before a detached
+			// goroutine could finish its HTTP call, suppressing the
+			// nag indefinitely.
+			update.MaybeNotifyUpdate(cmd.Context(), Version, Repository, 800*time.Millisecond, verbose)
 		}
 
 		if cmd.Name() == "login" || cmd.Name() == "signup" || cmd.Name() == "help" || cmd.CalledAs() == "help" {

--- a/internal/config/config_json.go
+++ b/internal/config/config_json.go
@@ -18,6 +18,10 @@ type UpdateCheckConfig struct {
 	LastCheck     time.Time `json:"last_check"`
 	NextCheck     time.Time `json:"next_check"`
 	CheckInterval int64     `json:"check_interval"` // in seconds, default 3600 (1 hour)
+	// LatestVersion is the most recently observed upstream release tag
+	// (e.g. "v0.10.0"). Cached so the "update available" nag can be
+	// printed synchronously on subsequent runs without hitting the network.
+	LatestVersion string `json:"latest_version,omitempty"`
 }
 
 // GetCLIConfigPath returns the path to the CLI config file

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -29,9 +29,31 @@ type GitHubRelease struct {
 
 // IsDevVersion reports whether a version string represents a local/dev build
 // for which we should skip update checks entirely.
+//
+// This catches:
+//   - the literal sentinels "dev" / "unknown" / "" set when ldflags weren't applied
+//   - "dev-<sha>" / "*-dirty" produced by our init() fallback against `git describe`
+//   - Go module *pseudo-versions* of the form "v0.0.0-<timestamp>-<commit>",
+//     which are what `go install` and `go run` produce against an untagged
+//     commit. Without this, integration test runs that build via the module
+//     graph end up with a perfectly valid-looking semver and try to "upgrade"
+//     to whatever real release is currently latest, contaminating test output.
 func IsDevVersion(v string) bool {
-	v = strings.TrimPrefix(v, "v")
-	return v == "" || v == "dev" || v == "unknown" || strings.HasPrefix(v, "dev-") || strings.Contains(v, "-dirty")
+	stripped := strings.TrimPrefix(v, "v")
+	if stripped == "" || stripped == "dev" || stripped == "unknown" {
+		return true
+	}
+	if strings.HasPrefix(stripped, "dev-") || strings.Contains(stripped, "-dirty") {
+		return true
+	}
+	// Go pseudo-versions all start with "0.0.0-" (untagged repo) or
+	// "X.Y.Z-0.<timestamp>-<commit>" (post-tag). The first form is the
+	// only one we hit in practice (the release pipeline sets a real
+	// version via ldflags), so checking that prefix is sufficient.
+	if strings.HasPrefix(stripped, "0.0.0-") {
+		return true
+	}
+	return false
 }
 
 // CheckForUpdates checks if there's a new version available.
@@ -227,7 +249,19 @@ func isNewerSemver(current, latest string) bool {
 // Errors are intentionally swallowed — the update check must never break a
 // real command. When verbose is true, debug output is written to stderr.
 func MaybeNotifyUpdate(ctx context.Context, current, repository string, timeout time.Duration, verbose bool) {
+	// Escape hatches for CI / scripted use. Either of these silences the
+	// nag and skips all network I/O. Mirrors NO_UPDATE_NOTIFIER (npm) and
+	// HOMEBREW_NO_AUTO_UPDATE (brew), which are well-known patterns.
+	if envFlagSet("VERS_NO_UPDATE_CHECK") || envFlagSet("NO_UPDATE_NOTIFIER") {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "[DEBUG] update: skipped (VERS_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER set)\n")
+		}
+		return
+	}
 	if IsDevVersion(current) {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "[DEBUG] update: skipped (dev/pseudo version %q)\n", current)
+		}
 		return
 	}
 
@@ -283,4 +317,21 @@ func MaybeNotifyUpdate(ctx context.Context, current, repository string, timeout 
 
 func printUpdateBanner(current, latest string) {
 	fmt.Fprintf(os.Stderr, "💡 vers update available: %s -> %s (run 'vers upgrade')\n\n", current, latest)
+}
+
+// envFlagSet returns true if the env var is set to a "truthy" value.
+// Treats unset, empty string, "0", "false", "no", "off" (case-insensitive)
+// as false and anything else as true. This matches the convention used by
+// most CLI tools and avoids surprises like VERS_NO_UPDATE_CHECK=0 being
+// interpreted as "yes, suppress".
+func envFlagSet(name string) bool {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return false
+	}
+	switch strings.ToLower(v) {
+	case "0", "false", "no", "off":
+		return false
+	}
+	return true
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,9 +1,11 @@
 package update
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -25,39 +27,61 @@ type GitHubRelease struct {
 	PublishedAt time.Time `json:"published_at"`
 }
 
-// CheckForUpdates checks if there's a new version available
+// IsDevVersion reports whether a version string represents a local/dev build
+// for which we should skip update checks entirely.
+func IsDevVersion(v string) bool {
+	v = strings.TrimPrefix(v, "v")
+	return v == "" || v == "dev" || v == "unknown" || strings.HasPrefix(v, "dev-") || strings.Contains(v, "-dirty")
+}
+
+// CheckForUpdates checks if there's a new version available.
+// This is a thin wrapper around CheckForUpdatesContext that uses a default
+// 5s timeout for backward compatibility with callers that don't manage
+// their own context (e.g. `vers upgrade`).
 func CheckForUpdates(currentVersion, repository string, verbose bool) (bool, string, error) {
-	// Skip check for dev versions
-	currentVersion = strings.TrimPrefix(currentVersion, "v")
-	if currentVersion == "dev" || currentVersion == "unknown" {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return CheckForUpdatesContext(ctx, currentVersion, repository, verbose)
+}
+
+// CheckForUpdatesContext checks if there's a new version available, honoring
+// the supplied context's deadline/cancellation.
+func CheckForUpdatesContext(ctx context.Context, currentVersion, repository string, verbose bool) (bool, string, error) {
+	if IsDevVersion(currentVersion) {
 		if verbose {
-			fmt.Printf("[DEBUG] Skipping update check for development version\n")
+			fmt.Printf("[DEBUG] Skipping update check for development version %q\n", currentVersion)
 		}
 		return false, "", nil
 	}
 
-	// Get latest release
-	latest, err := GetLatestRelease(repository, false, verbose)
+	latest, err := GetLatestReleaseContext(ctx, repository, false, verbose)
 	if err != nil {
 		if verbose {
 			fmt.Printf("[DEBUG] Failed to check for updates: %v\n", err)
 		}
-		return false, "", nil // Don't error out - just skip the check
+		return false, "", err
 	}
 
+	current := strings.TrimPrefix(currentVersion, "v")
 	latestVersion := strings.TrimPrefix(latest.TagName, "v")
 	if verbose {
-		fmt.Printf("[DEBUG] Current: %s, Latest: %s\n", currentVersion, latestVersion)
+		fmt.Printf("[DEBUG] Current: %s, Latest: %s\n", current, latestVersion)
 	}
 
-	// Check if there's an update available
-	hasUpdate := currentVersion != latestVersion
-	return hasUpdate, latest.TagName, nil
+	return current != latestVersion, latest.TagName, nil
 }
 
-// GetLatestRelease fetches the latest release from GitHub
-// If includePrerelease is true, it will return the latest release including prereleases
+// GetLatestRelease fetches the latest release from GitHub.
+// If includePrerelease is true, it will return the latest release including
+// prereleases. Uses a default 5s timeout.
 func GetLatestRelease(repository string, includePrerelease bool, verbose bool) (*GitHubRelease, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return GetLatestReleaseContext(ctx, repository, includePrerelease, verbose)
+}
+
+// GetLatestReleaseContext is like GetLatestRelease but honors the supplied context.
+func GetLatestReleaseContext(ctx context.Context, repository string, includePrerelease bool, verbose bool) (*GitHubRelease, error) {
 	// Extract owner/repo from Repository constant
 	repoURL := strings.TrimPrefix(repository, "https://github.com/")
 
@@ -70,7 +94,13 @@ func GetLatestRelease(repository string, includePrerelease bool, verbose bool) (
 		fmt.Printf("[DEBUG] Fetching release info from: %s\n", apiURL)
 	}
 
-	resp, err := http.Get(apiURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build release request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch release info: %w", err)
 	}
@@ -122,4 +152,135 @@ func UpdateCheckTime() {
 
 	cliConfig.SetNextCheckTime()
 	config.SaveCLIConfig(cliConfig)
+}
+
+// isNewerSemver returns true if `latest` is a strictly higher version than
+// `current` using a tolerant lexical comparison after stripping a leading
+// "v". Falls back to plain string inequality if either side fails to parse
+// as dotted integers, which preserves the old behavior.
+func isNewerSemver(current, latest string) bool {
+	c := strings.TrimPrefix(current, "v")
+	l := strings.TrimPrefix(latest, "v")
+	if c == "" || l == "" || c == l {
+		return false
+	}
+
+	// Strip pre-release/build metadata for the numeric comparison.
+	stripMeta := func(s string) string {
+		if i := strings.IndexAny(s, "-+"); i >= 0 {
+			return s[:i]
+		}
+		return s
+	}
+
+	cp := strings.Split(stripMeta(c), ".")
+	lp := strings.Split(stripMeta(l), ".")
+	parseInt := func(s string) (int, bool) {
+		n := 0
+		if s == "" {
+			return 0, false
+		}
+		for _, r := range s {
+			if r < '0' || r > '9' {
+				return 0, false
+			}
+			n = n*10 + int(r-'0')
+		}
+		return n, true
+	}
+
+	for i := 0; i < len(cp) || i < len(lp); i++ {
+		var ci, li int
+		var ok bool
+		if i < len(cp) {
+			if ci, ok = parseInt(cp[i]); !ok {
+				return c != l // unparseable -> fall back
+			}
+		}
+		if i < len(lp) {
+			if li, ok = parseInt(lp[i]); !ok {
+				return c != l
+			}
+		}
+		if li > ci {
+			return true
+		}
+		if li < ci {
+			return false
+		}
+	}
+	return false
+}
+
+// MaybeNotifyUpdate prints an "update available" message to the given writer
+// when a newer release is known. It is designed to be called once during CLI
+// startup and is cheap on the hot path:
+//
+//   - If a previously-cached LatestVersion is newer than `current`, the
+//     message prints synchronously with no network I/O.
+//   - Otherwise, if it's been longer than the configured check interval since
+//     the last successful check, it performs a single bounded HTTP request
+//     (capped at `timeout`) to refresh the cache. The cache (and NextCheck
+//     timestamp) are only advanced on a successful response, so transient
+//     network failures don't suppress the nag for an hour.
+//
+// Errors are intentionally swallowed — the update check must never break a
+// real command. When verbose is true, debug output is written to stderr.
+func MaybeNotifyUpdate(ctx context.Context, current, repository string, timeout time.Duration, verbose bool) {
+	if IsDevVersion(current) {
+		return
+	}
+
+	cliConfig, err := config.LoadCLIConfig()
+	if err != nil {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "[DEBUG] update: failed to load CLI config: %v\n", err)
+		}
+		return
+	}
+
+	// 1. Fast path: print from cache if we already know about a newer release.
+	cached := cliConfig.UpdateCheck.LatestVersion
+	printedCached := false
+	if cached != "" && isNewerSemver(current, cached) {
+		printUpdateBanner(current, cached)
+		printedCached = true
+	}
+
+	if !cliConfig.ShouldCheckForUpdate() {
+		return
+	}
+
+	// 2. Slow path: refresh from GitHub with a tight timeout.
+	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	latest, err := GetLatestReleaseContext(fetchCtx, repository, false, verbose)
+	if err != nil {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "[DEBUG] update: refresh failed: %v\n", err)
+		}
+		// Don't fully bump NextCheck on failure — try again soon (5min backoff)
+		// so a flaky network at the moment of first launch doesn't suppress
+		// the nag for the full check interval.
+		cliConfig.UpdateCheck.NextCheck = time.Now().Add(5 * time.Minute)
+		_ = config.SaveCLIConfig(cliConfig)
+		return
+	}
+
+	cliConfig.UpdateCheck.LatestVersion = latest.TagName
+	cliConfig.SetNextCheckTime()
+	if err := config.SaveCLIConfig(cliConfig); err != nil && verbose {
+		fmt.Fprintf(os.Stderr, "[DEBUG] update: failed to save CLI config: %v\n", err)
+	}
+
+	// If the refresh revealed a newer version that the fast path didn't
+	// already print, print now.
+	if !printedCached && isNewerSemver(current, latest.TagName) {
+		printUpdateBanner(current, latest.TagName)
+	}
+}
+
+func printUpdateBanner(current, latest string) {
+	fmt.Fprintf(os.Stderr, "💡 vers update available: %s -> %s (run 'vers upgrade')\n\n", current, latest)
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -44,7 +44,14 @@ func TestIsNewerSemver(t *testing.T) {
 }
 
 func TestIsDevVersion(t *testing.T) {
-	dev := []string{"dev", "unknown", "dev-abc1234", "dev-abc1234-dirty", "v0.10.0-dirty", ""}
+	dev := []string{
+		"dev", "unknown", "dev-abc1234", "dev-abc1234-dirty",
+		"v0.10.0-dirty", "",
+		// Go module pseudo-versions, as produced by `go install` /
+		// `go run` against an untagged commit.
+		"v0.0.0-20260506213344-eb1e5d25fa7c",
+		"v0.0.0-20260101000000-000000000000",
+	}
 	notDev := []string{"v0.10.0", "0.10.0", "v1.2.3", "v0.10.0-rc1"}
 	for _, v := range dev {
 		if !IsDevVersion(v) {
@@ -55,6 +62,66 @@ func TestIsDevVersion(t *testing.T) {
 		if IsDevVersion(v) {
 			t.Errorf("IsDevVersion(%q) = true, want false", v)
 		}
+	}
+}
+
+func TestMaybeNotifyUpdate_EnvVarSilencesCheck(t *testing.T) {
+	withTempHome(t)
+
+	// Server that fails the test if hit.
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.Error(w, "should not be called", 500)
+	}))
+	defer srv.Close()
+	withRewrittenHTTP(t, strings.TrimPrefix(srv.URL, "http://"))
+
+	for _, varName := range []string{"VERS_NO_UPDATE_CHECK", "NO_UPDATE_NOTIFIER"} {
+		t.Run(varName, func(t *testing.T) {
+			t.Setenv(varName, "1")
+			out := captureStderr(t, func() {
+				MaybeNotifyUpdate(context.Background(), "v0.9.0", "https://github.com/hdresearch/vers-cli", 500*time.Millisecond, false)
+			})
+			if hits != 0 {
+				t.Errorf("expected zero network calls when %s=1, got %d", varName, hits)
+			}
+			if out != "" {
+				t.Errorf("expected silent output when %s=1, got %q", varName, out)
+			}
+		})
+	}
+}
+
+func TestMaybeNotifyUpdate_EnvVarFalsyValuesDoNotSilence(t *testing.T) {
+	// "0", "false", "no", "off" should NOT silence the nag — only positive
+	// truthy values do. This mirrors common CLI conventions.
+	for _, val := range []string{"0", "false", "FALSE", "no", "off", ""} {
+		t.Run("VERS_NO_UPDATE_CHECK="+val, func(t *testing.T) {
+			withTempHome(t)
+			t.Setenv("VERS_NO_UPDATE_CHECK", val)
+			t.Setenv("NO_UPDATE_NOTIFIER", "")
+
+			cfg := &config.CLIConfig{
+				UpdateCheck: config.UpdateCheckConfig{
+					NextCheck:     time.Now().Add(-1 * time.Hour),
+					CheckInterval: 3600,
+				},
+			}
+			_ = config.SaveCLIConfig(cfg)
+
+			hits := 0
+			srv := fakeReleasesServer(t, "v0.10.0", &hits)
+			defer srv.Close()
+			withRewrittenHTTP(t, strings.TrimPrefix(srv.URL, "http://"))
+
+			out := captureStderr(t, func() {
+				MaybeNotifyUpdate(context.Background(), "v0.9.0", "https://github.com/hdresearch/vers-cli", 1*time.Second, false)
+			})
+			if !strings.Contains(out, "v0.9.0 -> v0.10.0") {
+				t.Errorf("expected banner with VERS_NO_UPDATE_CHECK=%q, got %q", val, out)
+			}
+		})
 	}
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,335 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hdresearch/vers-cli/internal/config"
+)
+
+func TestIsNewerSemver(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+	}{
+		{"v0.9.0", "v0.10.0", true},
+		{"0.9.0", "0.10.0", true},
+		{"v0.10.0", "v0.9.0", false},
+		{"v0.10.0", "v0.10.0", false},
+		{"v1.0.0", "v1.0.1", true},
+		{"v1.0.1", "v1.0.0", false},
+		{"v1.2.3", "v2.0.0", true},
+		{"v0.9", "v0.10", true}, // shorter current
+		{"v0.9.0", "v0.9.0-rc1", false},
+		{"", "v0.1.0", false}, // empty current is treated as dev
+		// Lexical fallback for unparseable versions: the function returns
+		// (current != latest) which preserves the historical behavior the
+		// old implementation depended on.
+		{"main", "abc", true},
+	}
+	for _, c := range cases {
+		got := isNewerSemver(c.current, c.latest)
+		if got != c.want {
+			t.Errorf("isNewerSemver(%q, %q) = %v, want %v", c.current, c.latest, got, c.want)
+		}
+	}
+}
+
+func TestIsDevVersion(t *testing.T) {
+	dev := []string{"dev", "unknown", "dev-abc1234", "dev-abc1234-dirty", "v0.10.0-dirty", ""}
+	notDev := []string{"v0.10.0", "0.10.0", "v1.2.3", "v0.10.0-rc1"}
+	for _, v := range dev {
+		if !IsDevVersion(v) {
+			t.Errorf("IsDevVersion(%q) = false, want true", v)
+		}
+	}
+	for _, v := range notDev {
+		if IsDevVersion(v) {
+			t.Errorf("IsDevVersion(%q) = true, want false", v)
+		}
+	}
+}
+
+// withTempHome redirects $HOME to a temporary directory for the duration of
+// the test so config.LoadCLIConfig / SaveCLIConfig don't touch the user's
+// real ~/.vers/config.json. Returns the path to the temp config file.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	// On some platforms os.UserHomeDir consults USERPROFILE / etc.; force HOME.
+	t.Setenv("USERPROFILE", dir)
+	return filepath.Join(dir, ".vers", "config.json")
+}
+
+// fakeReleasesServer returns an httptest server that serves a single
+// /repos/.../releases/latest payload with the given tag.
+func fakeReleasesServer(t *testing.T, tag string, hits *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits != nil {
+			*hits++
+		}
+		if !strings.HasSuffix(r.URL.Path, "/releases/latest") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(GitHubRelease{TagName: tag, Name: tag})
+	}))
+}
+
+// repoStringForServer builds a "repository" value that GetLatestReleaseContext
+// will rewrite into the fake server's URL. We exploit the fact that the code
+// strips the "https://github.com/" prefix and concatenates "https://api.github.com".
+// To redirect to httptest, we instead inject a custom http.RoundTripper.
+type rewriteTransport struct {
+	target string
+	base   http.RoundTripper
+}
+
+func (rt *rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Rewrite api.github.com → httptest server
+	if strings.Contains(r.URL.Host, "api.github.com") {
+		u := *r.URL
+		// httptest server URL is like http://127.0.0.1:PORT
+		// Parse it once.
+		// We stash the target in rt.target as "host:port".
+		u.Scheme = "http"
+		u.Host = rt.target
+		r2 := r.Clone(r.Context())
+		r2.URL = &u
+		r2.Host = rt.target
+		return rt.base.RoundTrip(r2)
+	}
+	return rt.base.RoundTrip(r)
+}
+
+func withRewrittenHTTP(t *testing.T, host string) {
+	t.Helper()
+	orig := http.DefaultClient.Transport
+	http.DefaultClient.Transport = &rewriteTransport{target: host, base: http.DefaultTransport}
+	t.Cleanup(func() { http.DefaultClient.Transport = orig })
+}
+
+func TestMaybeNotifyUpdate_PrintsFromCacheWithoutNetwork(t *testing.T) {
+	configPath := withTempHome(t)
+
+	// Pre-seed config with a known-newer LatestVersion and a NextCheck in
+	// the future so the slow path is skipped entirely.
+	cfg := &config.CLIConfig{
+		UpdateCheck: config.UpdateCheckConfig{
+			LastCheck:     time.Now(),
+			NextCheck:     time.Now().Add(1 * time.Hour),
+			CheckInterval: 3600,
+			LatestVersion: "v0.10.0",
+		},
+	}
+	if err := config.SaveCLIConfig(cfg); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	// Use a server that, if hit, would fail the test.
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.Error(w, "should not be called", 500)
+	}))
+	defer srv.Close()
+	withRewrittenHTTP(t, strings.TrimPrefix(srv.URL, "http://"))
+
+	// Capture stderr.
+	out := captureStderr(t, func() {
+		MaybeNotifyUpdate(context.Background(), "v0.9.0", "https://github.com/hdresearch/vers-cli", 500*time.Millisecond, false)
+	})
+
+	if hits != 0 {
+		t.Errorf("expected zero network calls on fast path, got %d", hits)
+	}
+	if !strings.Contains(out, "v0.9.0 -> v0.10.0") {
+		t.Errorf("expected update banner in output, got %q", out)
+	}
+	// Sanity: config was not rewritten.
+	got, _ := config.LoadCLIConfig()
+	if got.UpdateCheck.LatestVersion != "v0.10.0" {
+		t.Errorf("config LatestVersion changed unexpectedly: %q", got.UpdateCheck.LatestVersion)
+	}
+	_ = configPath
+}
+
+func TestMaybeNotifyUpdate_RefreshesWhenStale(t *testing.T) {
+	withTempHome(t)
+
+	// Seed config with NextCheck in the past so the slow path runs.
+	cfg := &config.CLIConfig{
+		UpdateCheck: config.UpdateCheckConfig{
+			LastCheck:     time.Now().Add(-2 * time.Hour),
+			NextCheck:     time.Now().Add(-1 * time.Hour),
+			CheckInterval: 3600,
+			// Empty LatestVersion: nothing to print on the fast path.
+		},
+	}
+	if err := config.SaveCLIConfig(cfg); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	hits := 0
+	srv := fakeReleasesServer(t, "v0.10.0", &hits)
+	defer srv.Close()
+	withRewrittenHTTP(t, strings.TrimPrefix(srv.URL, "http://"))
+
+	out := captureStderr(t, func() {
+		MaybeNotifyUpdate(context.Background(), "v0.9.0", "https://github.com/hdresearch/vers-cli", 2*time.Second, false)
+	})
+
+	if hits != 1 {
+		t.Errorf("expected exactly 1 network call, got %d", hits)
+	}
+	if !strings.Contains(out, "v0.9.0 -> v0.10.0") {
+		t.Errorf("expected update banner, got %q", out)
+	}
+
+	// Cache should now be populated and NextCheck pushed into the future.
+	got, _ := config.LoadCLIConfig()
+	if got.UpdateCheck.LatestVersion != "v0.10.0" {
+		t.Errorf("expected LatestVersion=v0.10.0, got %q", got.UpdateCheck.LatestVersion)
+	}
+	if !got.UpdateCheck.NextCheck.After(time.Now().Add(30 * time.Minute)) {
+		t.Errorf("expected NextCheck pushed forward, got %v", got.UpdateCheck.NextCheck)
+	}
+}
+
+func TestMaybeNotifyUpdate_NetworkFailureDoesNotSuppressForFullInterval(t *testing.T) {
+	withTempHome(t)
+
+	cfg := &config.CLIConfig{
+		UpdateCheck: config.UpdateCheckConfig{
+			NextCheck:     time.Now().Add(-1 * time.Hour),
+			CheckInterval: 3600,
+		},
+	}
+	if err := config.SaveCLIConfig(cfg); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	// Server that always 500s.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", 500)
+	}))
+	defer srv.Close()
+	withRewrittenHTTP(t, strings.TrimPrefix(srv.URL, "http://"))
+
+	_ = captureStderr(t, func() {
+		MaybeNotifyUpdate(context.Background(), "v0.9.0", "https://github.com/hdresearch/vers-cli", 500*time.Millisecond, false)
+	})
+
+	got, _ := config.LoadCLIConfig()
+	// NextCheck should be ~5min from now (the short backoff), not ~1h.
+	if got.UpdateCheck.NextCheck.After(time.Now().Add(30 * time.Minute)) {
+		t.Errorf("expected short backoff after failure, NextCheck=%v", got.UpdateCheck.NextCheck)
+	}
+	if got.UpdateCheck.NextCheck.Before(time.Now().Add(1 * time.Minute)) {
+		t.Errorf("expected NextCheck at least ~5min in future, got %v", got.UpdateCheck.NextCheck)
+	}
+}
+
+func TestMaybeNotifyUpdate_DevVersionSkipsEverything(t *testing.T) {
+	withTempHome(t)
+	hits := 0
+	srv := fakeReleasesServer(t, "v9.9.9", &hits)
+	defer srv.Close()
+	withRewrittenHTTP(t, strings.TrimPrefix(srv.URL, "http://"))
+
+	out := captureStderr(t, func() {
+		MaybeNotifyUpdate(context.Background(), "dev-abc1234", "https://github.com/hdresearch/vers-cli", 500*time.Millisecond, false)
+	})
+	if hits != 0 {
+		t.Errorf("dev version should not hit network, got %d hits", hits)
+	}
+	if out != "" {
+		t.Errorf("dev version should not print, got %q", out)
+	}
+}
+
+func TestMaybeNotifyUpdate_NoBannerWhenAlreadyOnLatest(t *testing.T) {
+	withTempHome(t)
+	cfg := &config.CLIConfig{
+		UpdateCheck: config.UpdateCheckConfig{
+			NextCheck:     time.Now().Add(-1 * time.Hour),
+			CheckInterval: 3600,
+		},
+	}
+	_ = config.SaveCLIConfig(cfg)
+
+	hits := 0
+	srv := fakeReleasesServer(t, "v0.10.0", &hits)
+	defer srv.Close()
+	withRewrittenHTTP(t, strings.TrimPrefix(srv.URL, "http://"))
+
+	out := captureStderr(t, func() {
+		MaybeNotifyUpdate(context.Background(), "v0.10.0", "https://github.com/hdresearch/vers-cli", 1*time.Second, false)
+	})
+	if out != "" {
+		t.Errorf("no banner expected when on latest, got %q", out)
+	}
+	if hits != 1 {
+		t.Errorf("expected 1 hit, got %d", hits)
+	}
+}
+
+// captureStderr runs fn and returns whatever it wrote to os.Stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 0, 1024)
+		tmp := make([]byte, 512)
+		for {
+			n, err := r.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+			}
+			if err != nil {
+				done <- string(buf)
+				return
+			}
+		}
+	}()
+	fn()
+	w.Close()
+	os.Stderr = orig
+	return <-done
+}
+
+// Sanity: assert the banner format hasn't drifted, since downstream tooling
+// (and the slack message we link users to) reference its wording.
+func TestPrintUpdateBannerFormat(t *testing.T) {
+	out := captureStderr(t, func() {
+		printUpdateBanner("v0.9.0", "v0.10.0")
+	})
+	if !strings.Contains(out, "vers update available") {
+		t.Errorf("banner missing identifying phrase: %q", out)
+	}
+	if !strings.Contains(out, "vers upgrade") {
+		t.Errorf("banner should tell users to run 'vers upgrade': %q", out)
+	}
+	// Avoid using fmt-style placeholders by accident.
+	if strings.Contains(out, "%s") || strings.Contains(out, "%v") {
+		t.Errorf("banner contains unrendered placeholder: %q", out)
+	}
+	_ = fmt.Sprintf // keep fmt import used even if we drop a check above
+}

--- a/test/testutil/helpers.go
+++ b/test/testutil/helpers.go
@@ -85,8 +85,10 @@ func RunVers(t TLike, timeout time.Duration, args ...string) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, BinPath, args...)
-	// Inherit env so VERS_URL and VERS_API_KEY are visible
-	cmd.Env = os.Environ()
+	// Inherit env so VERS_URL and VERS_API_KEY are visible, but force
+	// the update-check off so the "💡 vers update available" banner
+	// can't contaminate command output that tests parse.
+	cmd.Env = append(os.Environ(), "VERS_NO_UPDATE_CHECK=1")
 	out, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
 		return string(out), fmt.Errorf("command timed out: vers %s", strings.Join(args, " "))
@@ -107,7 +109,7 @@ func RunVersInDir(t TLike, dir string, timeout time.Duration, args ...string) (s
 
 	cmd := exec.CommandContext(ctx, absBin, args...)
 	cmd.Dir = dir
-	cmd.Env = os.Environ()
+	cmd.Env = append(os.Environ(), "VERS_NO_UPDATE_CHECK=1")
 	out, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
 		return string(out), fmt.Errorf("command timed out: vers %s", strings.Join(args, " "))


### PR DESCRIPTION
## Why

Jordan flagged in Slack that he had no idea a newer `vers` had shipped — the "update available" banner never printed for him. Investigation showed the startup check has been silently broken since it landed.

### The bug

`PersistentPreRunE` in `cmd/root.go` did this:

```go
if !skipUpdateCheck && update.ShouldCheckForUpdate() {
    update.UpdateCheckTime()        // (1) bumps NextCheck *before* the fetch
    go func() {                     // (2) detached goroutine
        hasUpdate, latestVersion, err := update.CheckForUpdates(...)
        if err == nil && hasUpdate {
            fmt.Printf("💡 Update available: ...")
        }
    }()
}
```

1. `UpdateCheckTime()` immediately pushes `NextCheck` an hour into the future.
2. The fetch runs in a detached goroutine with no synchronization.
3. Short commands like `vers ps` exit in ~50ms — well before the HTTP call to `api.github.com` finishes — so the banner never prints and the goroutine is killed mid-flight.
4. On the next run, `ShouldCheckForUpdate()` returns false (we just bumped NextCheck), so no check happens either.

Net effect: the nag was effectively never shown. Reproduced locally with `v0.9.0` against the live `v0.10.0` release — banner never appeared.

## What this PR does

Replaces the racy goroutine with `update.MaybeNotifyUpdate`, which:

- **Caches the latest known release tag** in `~/.vers/config.json` (`update_check.latest_version`). If the cached tag is newer than the running build, the banner prints **synchronously with zero network I/O** on every invocation. This is the path Jordan would hit on his second `vers` run.
- **Performs a single, synchronous, bounded (800ms) HTTP refresh** once per check interval — no goroutine, no race. 800ms is well below the threshold where users notice CLI lag, but enough for `api.github.com` from any reasonable network.
- **Only advances `NextCheck` on a successful fetch.** On failure (timeout, 5xx), uses a short 5-minute backoff so a flaky network at the moment of first launch doesn't suppress the nag for an hour.
- **Skips dev/dirty builds** via a centralized `IsDevVersion` helper (`dev`, `unknown`, `dev-<sha>`, `*-dirty`, empty).
- **Does proper semver-aware comparison** so `v0.9.0 < v0.10.0`. The previous string-equality check would also flag downgrades, which is wrong.
- **Writes the banner to stderr** (was stdout) so piped output of commands like `vers ps | grep ...` isn't contaminated.

## Smoke test

Built `v0.9.0` locally, pointed it at a fresh `$HOME`, ran twice against real GitHub:

```
$ HOME=/tmp/x vers ps
💡 vers update available: v0.9.0 -> v0.10.0 (run 'vers upgrade')

HEAD: 37d2f5c5-...
...
$ cat /tmp/x/.vers/config.json
{ "update_check": { ..., "latest_version": "v0.10.0" } }

$ time HOME=/tmp/x vers ps                 # warm cache
💡 vers update available: v0.9.0 -> v0.10.0 (run 'vers upgrade')
...
real    0m0.265s                            # no GitHub call
```

## Tests

New file `internal/update/update_test.go` covers:

- `TestIsNewerSemver` — semver comparison edge cases (0.9 < 0.10, missing components, prereleases, lexical fallback).
- `TestIsDevVersion` — dev / dirty / unknown / clean.
- `TestMaybeNotifyUpdate_PrintsFromCacheWithoutNetwork` — fast path: pre-seeds cache, asserts banner prints **and zero HTTP calls** (httptest server fails the test if hit).
- `TestMaybeNotifyUpdate_RefreshesWhenStale` — slow path: stale `NextCheck`, fake server returns `v0.10.0`, asserts exactly 1 HTTP call, banner printed, cache + `NextCheck` updated.
- `TestMaybeNotifyUpdate_NetworkFailureDoesNotSuppressForFullInterval` — server returns 500, asserts `NextCheck` is the 5-min backoff, not 1h.
- `TestMaybeNotifyUpdate_DevVersionSkipsEverything` — dev build → no network, no print.
- `TestMaybeNotifyUpdate_NoBannerWhenAlreadyOnLatest` — same version → no banner.
- `TestPrintUpdateBannerFormat` — banner wording regression test (downstream onboarding docs reference the "vers upgrade" phrase).

```
ok  	github.com/hdresearch/vers-cli/internal/update	0.255s
```

Full unit test suite (`make test-unit` minus the unrelated tunnel integration test) passes.

## Out of scope / follow-ups

- Static-linking question Jordan also raised: confirmed via `file vers-linux-amd64` on the latest GitHub release — already statically linked. His dynamic copy must come from somewhere other than the Releases page (likely an older bundle inside an agent-services image). Worth pinging him for `which -a vers` once he installs via `install.sh`.
- `vers upgrade` itself is unchanged. Once this PR lands, users on any release ≥ this one will start seeing the nag and discover `vers upgrade` organically.