### PR TITLE
fix: stop CI integration test flake by bumping APILong + test timeout

### DIFF
--- a/internal/app/timeouts.go
+++ b/internal/app/timeouts.go
@@ -16,7 +16,7 @@ func DefaultTimeouts() Timeouts {
 	return Timeouts{
 		APIShort:    10 * time.Second,
 		APIMedium:   30 * time.Second,
-		APILong:     60 * time.Second,
+		APILong:     120 * time.Second,
 		BuildUpload: 600 * time.Second,
 		SSHConnect:  5 * time.Second,
 	}

--- a/test/testutil/helpers.go
+++ b/test/testutil/helpers.go
@@ -14,7 +14,11 @@ import (
 )
 
 const (
-	DefaultTimeout = 60 * time.Second
+	// DefaultTimeout caps each `vers` invocation in integration tests.
+	// Must exceed the CLI's longest internal context budget (APILong = 120s)
+	// so the CLI gets room to either succeed or return a clean
+	// context-deadline error before the test wrapper kills the process.
+	DefaultTimeout = 180 * time.Second
 )
 
 var (


### PR DESCRIPTION
## Problem

Integration tests have been flaking in CI on every recent PR — typically `TestBranchLifecycle` or `TestCommitAndRunCommit` timing out on a `vers branch` or `vers run-commit` invocation. Three reruns of #183 each failed on a different live-API call, all with the same 60–77s timeout shape. PR #190 hit the same flake and required a rerun.

## Root cause

Two timeouts were both set to **60s**:

| Knob | Where | Default |
|---|---|---|
| `APILong` | `internal/app/timeouts.go` | 60s — CLI's own context budget for long API calls |
| `testutil.DefaultTimeout` | `test/testutil/helpers.go` | 60s — integration-test wrapper kills the `vers` process |

The test wrapper had **zero margin** over the CLI's internal timeout. When VM provisioning legitimately took ≥60s, both timers raced — the test wrapper killed the process before the CLI could either complete or surface a clean deadline-exceeded error.

## Empirical evidence

Local stress test on the previously-flaky pair (`TestCommitAndRunCommit`, `TestBranchLifecycle`):

| Conditions | Result |
|---|---|
| Tests run in isolation | `vers branch` consistently 13–16s, always passes |
| Run individually outside the test runner | `vers branch` 5–6s |
| Full integration suite, old timeouts (60s/60s) | 50% flake rate locally; 100% flake rate across 3 CI reruns |
| Full integration suite, new timeouts (120s/180s) | 4 consecutive passes locally: 138s, 86s, 89s, 86s |

When the full suite runs, `vers branch` *can* take 60+ seconds — likely API state / queue interference from prior tests in the same run. Not a hot-path issue but a real tail.

## Fix

- **`APILong: 60s → 120s`** — gives the CLI's own context budget room to complete or error gracefully on slow VM provisioning
- **`testutil.DefaultTimeout: 60s → 180s`** — keeps the test wrapper strictly above `APILong` so the CLI can return a clean error before the wrapper kills it
- Added a comment in `test/testutil/helpers.go` documenting the invariant

## Validation

```
$ for i in 1 2 3 4; do go test -timeout 15m ./test/...; done
ok  github.com/hdresearch/vers-cli/test  138.015s
ok  github.com/hdresearch/vers-cli/test   85.878s
ok  github.com/hdresearch/vers-cli/test   88.894s
ok  github.com/hdresearch/vers-cli/test   86.365s
```

Build, vet, gofmt all clean. Unit tests unchanged.

## User-visible impact

`APILong` governs CLI commands that hit long-running endpoints (`vers run`, `vers branch`, `vers run-commit`, etc.). Today, those error after 60s with `context deadline exceeded`. With this change, they error after 120s instead. Users who were relying on a fast-fail at 60s will now wait up to twice as long for a real failure — but in practice the increased budget will prevent spurious failures on slow VM provisioning, which is the common case the empirical data points to.

Agents using `--wait` are unaffected (the wait loop has its own retry/poll logic independent of `APILong`).

Closes the flake pattern that's been hitting #183, #190, and any future PR running integration tests.