### PR TITLE
fix(stderr): route diagnostics to stderr, keep stdout for data

### DIFF
--- a/internal/handlers/kill.go
+++ b/internal/handlers/kill.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/hdresearch/vers-cli/internal/app"
 	"github.com/hdresearch/vers-cli/internal/presenters"
@@ -30,7 +31,7 @@ func HandleKill(ctx context.Context, a *app.App, r KillReq) error {
 	// Confirm if needed
 	if !r.SkipConfirmation {
 		for _, t := range targets {
-			fmt.Printf("Warning: You are about to delete VM '%s'\n", t)
+			fmt.Fprintf(os.Stderr, "Warning: You are about to delete VM '%s'\n", t)
 		}
 		ok, _ := a.Prompter.YesNo("Proceed")
 		if !ok {

--- a/internal/handlers/upgrade.go
+++ b/internal/handlers/upgrade.go
@@ -107,7 +107,7 @@ func performUpgrade(DebugPrint func(string, ...any), release *update.GitHubRelea
 		}
 		fmt.Println("Checksum verification passed")
 	} else if skipChecksum {
-		fmt.Println("warning: skipping checksum verification (not recommended)")
+		fmt.Fprintln(os.Stderr, "warning: skipping checksum verification (not recommended)")
 	}
 
 	currentExe, err := os.Executable()

--- a/internal/presenters/branch_presenter.go
+++ b/internal/presenters/branch_presenter.go
@@ -2,6 +2,7 @@ package presenters
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/hdresearch/vers-cli/internal/app"
 )
@@ -12,7 +13,7 @@ func RenderBranch(a *app.App, res BranchView) {
 		newIDs = []string{res.NewID}
 	}
 	if len(newIDs) == 0 {
-		fmt.Println("Error: no VM IDs returned from branch operation")
+		fmt.Fprintln(os.Stderr, "Error: no VM IDs returned from branch operation")
 		return
 	}
 	numNew := len(newIDs)
@@ -50,7 +51,7 @@ func RenderBranch(a *app.App, res BranchView) {
 	}
 
 	if res.CheckoutErr != nil {
-		fmt.Printf("WARNING: Failed to update HEAD: %v\n", res.CheckoutErr)
+		fmt.Fprintf(os.Stderr, "WARNING: Failed to update HEAD: %v\n", res.CheckoutErr)
 		return
 	}
 

--- a/internal/presenters/run_presenter.go
+++ b/internal/presenters/run_presenter.go
@@ -2,6 +2,7 @@ package presenters
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/hdresearch/vers-cli/internal/app"
 )
@@ -18,6 +19,6 @@ func RenderRun(a *app.App, v RunView) {
 	if v.HeadTarget != "" {
 		fmt.Printf("HEAD now points to: %s\n", v.HeadTarget)
 	} else {
-		fmt.Println("Warning: .vers directory not found. Run 'vers init' first.")
+		fmt.Fprintln(os.Stderr, "Warning: .vers directory not found. Run 'vers init' first.")
 	}
 }

--- a/internal/runconfig/config.go
+++ b/internal/runconfig/config.go
@@ -55,7 +55,7 @@ func Default() *Config {
 func Load() (*Config, error) {
 	cfg := Default()
 	if _, err := os.Stat("vers.toml"); os.IsNotExist(err) {
-		fmt.Println("Warning: vers.toml not found, using default configuration")
+		fmt.Fprintln(os.Stderr, "Warning: vers.toml not found, using default configuration")
 		return cfg, nil
 	}
 	if _, err := toml.DecodeFile("vers.toml", cfg); err != nil {


### PR DESCRIPTION
## Problem

`vers run --json` emits the `Warning: vers.toml not found, using default configuration` line on **stdout**, contaminating JSON output and breaking the canonical `vers run --json | jq` pipeline:

```
$ vers run --json 2>/dev/null
Warning: vers.toml not found, using default configuration   ← still here, on stdout
{
  "vm_id": "...",
  "head": "..."
}
$ vers run --json | jq .
jq: parse error: Invalid numeric literal at line 1, column 8
```

Same shape elsewhere — six diagnostics across runconfig, presenters, and handlers were using `fmt.Println` / `fmt.Printf` (stdout) instead of stderr.

## Fix

Five files, swap `fmt.Println` → `fmt.Fprintln(os.Stderr, …)` and `fmt.Printf` → `fmt.Fprintf(os.Stderr, …)` for the offending diagnostics:

| File | Diagnostic |
|---|---|
| `internal/runconfig/config.go` | `vers.toml not found` warning (the headline bug) |
| `internal/presenters/run_presenter.go` | `.vers directory not found` warning |
| `internal/presenters/branch_presenter.go` | `no VM IDs returned` error + `Failed to update HEAD` warning |
| `internal/handlers/upgrade.go` | `skipping checksum verification` warning |
| `internal/handlers/kill.go` | `about to delete VM` confirmation header (precedes the interactive prompt) |

## Verification

```
$ vers run --json 2>/dev/null
{
  "vm_id": "a46c92a9-36b2-477a-a6f6-694b74945b09",
  "head": "a46c92a9-36b2-477a-a6f6-694b74945b09"
}

$ vers run --json 2>&1 >/dev/null
Warning: vers.toml not found, using default configuration

$ vers run --json | jq .vm_id
"a46c92a9-36b2-477a-a6f6-694b74945b09"
```

`make build`, `gofmt`, `go test ./internal/... ./cmd/...` all clean.

Addresses agent-native CLI principle 2 (data on stdout, diagnostics on stderr) from the audit. Not a comprehensive sweep — only fixes the cases I happened to see in this session. A broader pass over every `fmt.Println` / `fmt.Printf` callsite in `internal/` is worth doing as a follow-up.