### PR TITLE
feat(auth): persist org_name and org_id from login/signup

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -188,7 +188,7 @@ func loginWithGit() error {
 		return err
 	}
 
-	if err := auth.SaveAPIKey(keyResp.APIKey); err != nil {
+	if err := auth.SaveAuth(keyResp.APIKey, keyResp.OrgName, keyResp.OrgID); err != nil {
 		return fmt.Errorf("error saving API key: %w", err)
 	}
 

--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -146,6 +146,8 @@ func signupWithGit() error {
 	config.APIKey = keyResp.APIKey
 	config.Email = email
 	config.SSHKeyPath = sshKeyPath
+	config.OrgName = keyResp.OrgName
+	config.OrgID = keyResp.OrgID
 	if err := auth.SaveConfig(config); err != nil {
 		return fmt.Errorf("error saving config: %w", err)
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -18,6 +18,13 @@ type Config struct {
 	APIKey     string `json:"apiKey"`
 	Email      string `json:"email,omitempty"`
 	SSHKeyPath string `json:"sshKeyPath,omitempty"`
+	// OrgName is the user's organization name (namespace).
+	// Persisted from the login/signup API response so that callers can
+	// compose canonical references (e.g. <org>/<repo>:<tag>) without
+	// an extra API round-trip.
+	OrgName string `json:"orgName,omitempty"`
+	// OrgID is the user's organization UUID, persisted alongside OrgName.
+	OrgID string `json:"orgID,omitempty"`
 }
 
 // GetConfigPath returns the path to the .versrc file in the user's home directory
@@ -103,6 +110,38 @@ func SaveAPIKey(apiKey string) error {
 
 	config.APIKey = apiKey
 	return SaveConfig(config)
+}
+
+// SaveAuth persists the API key plus org identity to the config file in a
+// single write. Use this from the login/signup paths so that subsequent
+// commands can read the user's org name without an extra API call.
+func SaveAuth(apiKey, orgName, orgID string) error {
+	config, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	config.APIKey = apiKey
+	if orgName != "" {
+		config.OrgName = orgName
+	}
+	if orgID != "" {
+		config.OrgID = orgID
+	}
+	return SaveConfig(config)
+}
+
+// GetOrgName returns the user's org name, preferring the VERS_ORG env var
+// over the persisted config value. Empty string if neither is set.
+func GetOrgName() (string, error) {
+	if orgName := os.Getenv("VERS_ORG"); orgName != "" {
+		return orgName, nil
+	}
+	config, err := LoadConfig()
+	if err != nil {
+		return "", err
+	}
+	return config.OrgName, nil
 }
 
 // HasAPIKey checks if an API key is present in environment variable or config file

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -33,3 +33,71 @@ func TestGetVMDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOrgName(t *testing.T) {
+	// Save and restore HOME / VERS_ORG so this test is hermetic.
+	origHome := os.Getenv("HOME")
+	origOrg := os.Getenv("VERS_ORG")
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		if origOrg == "" {
+			os.Unsetenv("VERS_ORG")
+		} else {
+			os.Setenv("VERS_ORG", origOrg)
+		}
+	})
+
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+	os.Unsetenv("VERS_ORG")
+
+	// 1. No config file, no env var → empty.
+	got, err := GetOrgName()
+	if err != nil {
+		t.Fatalf("GetOrgName with no config: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+
+	// 2. Persist via SaveAuth, read back.
+	if err := SaveAuth("test-key", "acme", "org-uuid-1"); err != nil {
+		t.Fatalf("SaveAuth: %v", err)
+	}
+	got, err = GetOrgName()
+	if err != nil {
+		t.Fatalf("GetOrgName after SaveAuth: %v", err)
+	}
+	if got != "acme" {
+		t.Errorf("expected acme, got %q", got)
+	}
+
+	// 3. Env var wins over persisted value.
+	os.Setenv("VERS_ORG", "override-org")
+	got, err = GetOrgName()
+	if err != nil {
+		t.Fatalf("GetOrgName with env override: %v", err)
+	}
+	if got != "override-org" {
+		t.Errorf("expected override-org, got %q", got)
+	}
+
+	// 4. Empty SaveAuth values don't clobber persisted ones.
+	os.Unsetenv("VERS_ORG")
+	if err := SaveAuth("new-key", "", ""); err != nil {
+		t.Fatalf("SaveAuth empty org: %v", err)
+	}
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.APIKey != "new-key" {
+		t.Errorf("expected new-key, got %q", cfg.APIKey)
+	}
+	if cfg.OrgName != "acme" {
+		t.Errorf("expected acme preserved, got %q", cfg.OrgName)
+	}
+	if cfg.OrgID != "org-uuid-1" {
+		t.Errorf("expected org-uuid-1 preserved, got %q", cfg.OrgID)
+	}
+}


### PR DESCRIPTION
## Why

When a user runs `vers login` or `vers signup`, the API response includes both `org_name` and `org_id`. The CLI prints them in the success banner and then discards them. That makes the canonical `<org>/<repo>:<tag>` reference unconstructable client-side, even though the server already told us the org name.

Surfaced naturally while documenting how to share a public repo: `vers repo get pi-agent` doesn't say what org `pi-agent` belongs to, because the API's `RepositoryInfo` response doesn't include it (`PublicRepositoryInfo` does, but that's a different endpoint). Without persisted org info, a user can't construct their own public reference without the upstream API including it on every endpoint.

## What

1. **`Config` struct gains `OrgName` and `OrgID` fields** (omitempty so existing `~/.versrc` files don't gain noisy keys).
2. **New `SaveAuth(apiKey, orgName, orgID)` helper** — single write, used by login. Empty values don't clobber persisted ones, so a future key-only rotation preserves org identity.
3. **New `GetOrgName()` helper** — mirrors `GetAPIKey`: `VERS_ORG` env wins, falls back to config.
4. **Login + signup paths updated** to persist org info on success.

## Doesn't include (deliberate follow-ups, not yet tracked)

- Surfacing `org_name` in `vers agent-context` — a natural addition; this PR unblocks it but doesn't ship it
- `vers repo get` synthesizing `<org>/<repo>:<tag>` client-side
- `vers whoami` to introspect the persisted identity

A follow-up issue should be filed for these. Issue #193 currently only covers the `feedback` and `jobs` blocks of `agent-context`; org/identity surfacing is a separate concern.

## Tests

New `TestGetOrgName` with 4 sub-cases:

```
--- PASS: TestGetOrgName (0.00s)
```

Covers: no config returns empty, persist-and-read, `VERS_ORG` env override, empty values to `SaveAuth` don't clobber existing.

All existing tests pass. `make build`, `gofmt`, `go vet` clean.

## Backwards compatibility

Strictly additive. Existing `~/.versrc` files without `orgName`/`orgID` continue to work; the fields populate on next login/signup. No breaking change.